### PR TITLE
Fix golangci-lint errors/warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 vendor/
+
+/mp4/test_data/out_init.cmfv

--- a/bits/bits_benchmark_test.go
+++ b/bits/bits_benchmark_test.go
@@ -9,6 +9,8 @@ func BenchmarkWrite(b *testing.B) {
 	writer := NewWriter(ioutil.Discard)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		writer.Write(0xff, 8)
+		if err := writer.Write(0xff, 8); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/cmd/mp4ff-pslister/main.go
+++ b/cmd/mp4ff-pslister/main.go
@@ -32,10 +32,10 @@ func main() {
 	}
 
 	ifd, err := os.Open(*fileName)
-	defer ifd.Close()
 	if err != nil {
 		log.Fatalln(err)
 	}
+	defer ifd.Close()
 	parsedMp4, err := mp4.DecodeFile(ifd)
 	if err != nil {
 		log.Fatalln(err)

--- a/mp4/audiosampleentry_test.go
+++ b/mp4/audiosampleentry_test.go
@@ -6,12 +6,14 @@ import (
 )
 
 func TestWriteReadOfAudioSampleEntry(t *testing.T) {
-
 	ase := CreateAudioSampleEntryBox("mp4a", 2, 16, 48000, nil)
 
 	// Write to a buffer so that we can read and check
 	var buf bytes.Buffer
-	ase.Encode(&buf)
+	err := ase.Encode(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Read back from buffer
 	decodedBox, err := DecodeBox(0, &buf)

--- a/mp4/audiosamplentry.go
+++ b/mp4/audiosamplentry.go
@@ -141,7 +141,10 @@ func (a *AudioSampleEntryBox) Encode(w io.Writer) error {
 
 	// Next output child boxes in order
 	for _, child := range a.boxes {
-		child.Encode(w)
+		err = child.Encode(w)
+		if err != nil {
+			return err
+		}
 	}
 	return err
 }

--- a/mp4/avc.go
+++ b/mp4/avc.go
@@ -25,11 +25,6 @@ const (
 // AvcNalType -
 type AvcNalType uint16
 
-func isVideoNalu(b []byte) bool {
-	typ := b[0] & 0x1f
-	return 1 <= typ && typ <= 5
-}
-
 // FindAvcNalTypes - find list of nal types
 func FindAvcNalTypes(b []byte) []AvcNalType {
 	var pos uint32 = 0
@@ -191,8 +186,7 @@ func ParseSPSNALUnit(data []byte) (*AvcSPS, error) {
 		sps.OffsetForNonRefPic = reader.MustReadExpGolomb()
 		sps.OffsetForTopToBottomField = reader.MustReadExpGolomb()
 		numRefFramesInPicOrderCntCycle := reader.MustReadExpGolomb()
-		sps.RefFramesInPicOrderCntCycle = make([]uint, numRefFramesInPicOrderCntCycle,
-			numRefFramesInPicOrderCntCycle)
+		sps.RefFramesInPicOrderCntCycle = make([]uint, numRefFramesInPicOrderCntCycle)
 		for i := 0; i < int(numRefFramesInPicOrderCntCycle); i++ {
 			sps.RefFramesInPicOrderCntCycle[i] = reader.MustReadExpGolomb()
 		}
@@ -247,7 +241,10 @@ func ParseSPSNALUnit(data []byte) (*AvcSPS, error) {
 	vuiParametersPresentFlag := reader.MustReadFlag()
 	sps.NrBytesBeforeVUI = reader.NrBytesRead()
 	if vuiParametersPresentFlag {
-		parseVUI(reader, &sps.VUI, true)
+		err := parseVUI(reader, &sps.VUI, true)
+		if err != nil {
+			return nil, err
+		}
 
 	}
 	sps.NrBytesRead = reader.NrBytesRead()

--- a/mp4/avcc.go
+++ b/mp4/avcc.go
@@ -49,6 +49,5 @@ func (a *AvcCBox) Encode(w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	a.AVCDecConfRec.Encode(w)
-	return nil
+	return a.AVCDecConfRec.Encode(w)
 }

--- a/mp4/box.go
+++ b/mp4/box.go
@@ -188,27 +188,11 @@ func (f Fixed16) String() string {
 	return fmt.Sprintf("%d.%d", uint16(f)>>8, uint16(f)&7)
 }
 
-func fixed16(bytes []byte) Fixed16 {
-	return Fixed16(binary.BigEndian.Uint16(bytes))
-}
-
-func putFixed16(bytes []byte, i Fixed16) {
-	binary.BigEndian.PutUint16(bytes, uint16(i))
-}
-
 // Fixed32 -  A 16.16 fixed point number
 type Fixed32 uint32
 
 func (f Fixed32) String() string {
 	return fmt.Sprintf("%d.%d", uint32(f)>>16, uint32(f)&15)
-}
-
-func fixed32(bytes []byte) Fixed32 {
-	return Fixed32(binary.BigEndian.Uint32(bytes))
-}
-
-func putFixed32(bytes []byte, i Fixed32) {
-	binary.BigEndian.PutUint32(bytes, uint32(i))
 }
 
 func strtobuf(out []byte, str string, l int) {

--- a/mp4/btrt.go
+++ b/mp4/btrt.go
@@ -40,13 +40,23 @@ func (b *BtrtBox) Size() uint64 {
 
 // Encode - write box to w
 func (b *BtrtBox) Encode(w io.Writer) error {
-	err := EncodeHeader(b, w)
+	var err error
+
+	err = EncodeHeader(b, w)
 	if err != nil {
 		return err
 	}
 
-	binary.Write(w, binary.BigEndian, b.BufferSizeDB)
-	binary.Write(w, binary.BigEndian, b.MaxBitrate)
-	binary.Write(w, binary.BigEndian, b.AvgBitrate)
-	return nil
+	write := func(b uint32) {
+		if err != nil {
+			return
+		}
+		err = binary.Write(w, binary.BigEndian, b)
+	}
+
+	write(b.BufferSizeDB)
+	write(b.MaxBitrate)
+	write(b.AvgBitrate)
+
+	return err
 }

--- a/mp4/elng.go
+++ b/mp4/elng.go
@@ -49,7 +49,10 @@ func (b *ElngBox) Encode(w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	w.Write([]byte(b.Language))
-	w.Write([]byte{0})
+	_, err = w.Write([]byte(b.Language))
+	if err != nil {
+		return err
+	}
+	_, err = w.Write([]byte{0})
 	return err
 }

--- a/mp4/elng_test.go
+++ b/mp4/elng_test.go
@@ -38,7 +38,7 @@ func TestEncodeElng(t *testing.T) {
 	if err != nil {
 		t.Errorf("Could not encode ElngBox")
 	}
-	if string(buf.Bytes()) != elngString {
+	if buf.String() != elngString {
 		t.Error("elng output box is not correct.")
 	}
 }

--- a/mp4/esds.go
+++ b/mp4/esds.go
@@ -1,6 +1,7 @@
 package mp4
 
 import (
+	"errors"
 	"io"
 	"io/ioutil"
 )
@@ -96,7 +97,7 @@ func DecodeEsds(hdr *boxHeader, startPos uint64, r io.Reader) (Box, error) {
 		EsDescrTag: s.ReadUint8(),
 	}
 
-	size, nrBytesRead := readSizeOfInstance(s)
+	_, nrBytesRead := readSizeOfInstance(s)
 	e.nrExtraSizeBytes += nrBytesRead - 1
 
 	e.EsID = s.ReadUint16()
@@ -104,7 +105,7 @@ func DecodeEsds(hdr *boxHeader, startPos uint64, r io.Reader) (Box, error) {
 	e.FlagsAndPriority = s.ReadUint8()
 	e.DecoderConfigDescrTag = s.ReadUint8()
 
-	size, nrBytesRead = readSizeOfInstance(s)
+	_, nrBytesRead = readSizeOfInstance(s)
 	e.nrExtraSizeBytes += nrBytesRead - 1
 	e.ObjectType = s.ReadUint8()
 
@@ -114,14 +115,14 @@ func DecodeEsds(hdr *boxHeader, startPos uint64, r io.Reader) (Box, error) {
 	e.MaxBitrate = s.ReadUint32()
 	e.AvgBitrate = s.ReadUint32()
 	e.DecSpecificInfoTag = s.ReadUint8()
-	size, nrBytesRead = readSizeOfInstance(s)
+	size, nrBytesRead := readSizeOfInstance(s)
 	e.nrExtraSizeBytes += nrBytesRead - 1
 	e.DecConfig = s.ReadBytes(size)
 	e.SLConfigDescrTag = s.ReadUint8()
 	size, nrBytesRead = readSizeOfInstance(s)
 	e.nrExtraSizeBytes += nrBytesRead - 1
 	if size != 1 {
-		panic("Cannot handle SLConfigDescr not equal to 1 byte")
+		return e, errors.New("Cannot handle SLConfigDescr not equal to 1 byte")
 	}
 	e.SLConfigValue = s.ReadUint8()
 	return e, nil

--- a/mp4/esds_test.go
+++ b/mp4/esds_test.go
@@ -7,14 +7,16 @@ import (
 )
 
 func TestEsdsEncodeAndDecode(t *testing.T) {
-
 	decCfg := []byte{0x11, 0x90}
 
 	esdsIn := CreateEsdsBox(decCfg)
 
 	// Write to a buffer so that we can read and check
 	var buf bytes.Buffer
-	esdsIn.Encode(&buf)
+	err := esdsIn.Encode(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Read back from buffer
 	decodedBox, err := DecodeBox(0, &buf)
@@ -23,7 +25,7 @@ func TestEsdsEncodeAndDecode(t *testing.T) {
 	}
 	esdsOut := decodedBox.(*EsdsBox)
 	decCfgOut := esdsOut.DecConfig
-	if bytes.Compare(decCfgOut, decCfg) != 0 {
+	if !bytes.Equal(decCfgOut, decCfg) {
 		t.Errorf("Decode cfg out %s differs from decode cfg in %s",
 			hex.EncodeToString(decCfgOut), hex.EncodeToString(decCfg))
 	}

--- a/mp4/fragment.go
+++ b/mp4/fragment.go
@@ -98,7 +98,7 @@ func (f *Fragment) AddSample(s *SampleComplete) {
 }
 
 // DumpSampleData - Get Sample data and print out
-func (f *Fragment) DumpSampleData(w io.Writer, trex *TrexBox) {
+func (f *Fragment) DumpSampleData(w io.Writer, trex *TrexBox) error {
 	samples := f.GetSampleData(trex)
 	for i, s := range samples {
 		if i < 9 {
@@ -106,9 +106,13 @@ func (f *Fragment) DumpSampleData(w io.Writer, trex *TrexBox) {
 		}
 		toAnnexB(s.Data)
 		if w != nil {
-			w.Write(s.Data)
+			_, err := w.Write(s.Data)
+			if err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }
 
 // Encode - write fragment via writer

--- a/mp4/initsegment_test.go
+++ b/mp4/initsegment_test.go
@@ -83,7 +83,6 @@ func TestMoovParsingWithBtrtParsing(t *testing.T) {
 const pps1nalu = "68b5df20"
 
 func TestGenerateInitSegment(t *testing.T) {
-
 	spsData, _ := hex.DecodeString(sps1nalu)
 	pps, _ := hex.DecodeString(pps1nalu)
 	ppsData := [][]byte{pps}
@@ -98,7 +97,10 @@ func TestGenerateInitSegment(t *testing.T) {
 	}
 	// Write to a buffer so that we can read and check
 	var buf bytes.Buffer
-	init.Encode(&buf)
+	err := init.Encode(&buf)
+	if err != nil {
+		t.Error(err)
+	}
 
 	initRead, err := DecodeFile(&buf)
 	if err != io.EOF && err != nil {
@@ -112,9 +114,12 @@ func TestGenerateInitSegment(t *testing.T) {
 
 	// Next write to a file
 	ofd, err := os.Create("test_data/out_init.cmfv")
-	defer ofd.Close()
 	if err != nil {
 		t.Error(err)
 	}
-	init.Encode(ofd)
+	defer ofd.Close()
+	err = init.Encode(ofd)
+	if err != nil {
+		t.Error(err)
+	}
 }

--- a/mp4/mdat_test.go
+++ b/mp4/mdat_test.go
@@ -46,15 +46,20 @@ func TestEncodeAndDecodeMdat(t *testing.T) {
 
 // TestDecodeLargeSize - decode an mdat box where size is encoded as 64-bit largeSize
 func TestDecodeLargeSize(t *testing.T) {
-
 	// Build mdat box which uses largesize
 	var buf bytes.Buffer
 	var specialSize uint32 = 1 // This signals that largeSize is used
-	binary.Write(&buf, binary.BigEndian, specialSize)
+	err := binary.Write(&buf, binary.BigEndian, specialSize)
+	if err != nil {
+		t.Error(err)
+	}
 	buf.Write([]byte("mdat"))
 	sample := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
 	var largeSize uint64 = uint64(8 + 8 + len(sample))
-	binary.Write(&buf, binary.BigEndian, largeSize)
+	err = binary.Write(&buf, binary.BigEndian, largeSize)
+	if err != nil {
+		t.Error(err)
+	}
 	buf.Write(sample)
 
 	box, err := DecodeBox(0, &buf)

--- a/mp4/mediasegment_test.go
+++ b/mp4/mediasegment_test.go
@@ -46,9 +46,15 @@ func TestMediaSegmentFragmentation(t *testing.T) {
 
 	// Write to a buffer so that we can read and check
 	var buf bytes.Buffer
-	f.Segments[0].Styp.Encode(&buf)
+	err = f.Segments[0].Styp.Encode(&buf)
+	if err != nil {
+		t.Error(err)
+	}
 	for _, frag := range fragments {
-		frag.Encode(&buf)
+		err = frag.Encode(&buf)
+		if err != nil {
+			t.Error(err)
+		}
 	}
 
 	inFileContent, err := ioutil.ReadFile("test_data/1_frag.m4s")
@@ -56,7 +62,7 @@ func TestMediaSegmentFragmentation(t *testing.T) {
 		t.Errorf("Could not read test content")
 	}
 	outFileContent := buf.Bytes()
-	if bytes.Compare(outFileContent, inFileContent) != 0 {
+	if !bytes.Equal(outFileContent, inFileContent) {
 		t.Errorf("Wanted outfile len %d but got len %d", len(inFileContent), len(outFileContent))
 	}
 }

--- a/mp4/mvhd_test.go
+++ b/mp4/mvhd_test.go
@@ -10,7 +10,10 @@ func TestMvhd(t *testing.T) {
 	var buf bytes.Buffer
 
 	mvhdCreated := CreateMvhd()
-	mvhdCreated.Encode(&buf)
+	err := mvhdCreated.Encode(&buf)
+	if err != nil {
+		t.Error(err)
+	}
 
 	if uint64(buf.Len()) != mvhdCreated.Size() {
 		t.Errorf("Mismatch bytes written %d not equal to size %d", buf.Len(), mvhdCreated.Size())

--- a/mp4/tfdt_test.go
+++ b/mp4/tfdt_test.go
@@ -55,18 +55,23 @@ func TestTfdtWriteV1(t *testing.T) {
 		size:   uint64(len(byteData)/2 + 8),
 		hdrlen: 8,
 	}
-	box, _ := DecodeTfdt(bHdr, 0, r)
+	box, err := DecodeTfdt(bHdr, 0, r)
+	if err != nil {
+		t.Error(err)
+	}
 	tfdt := box.(*TfdtBox)
 
 	outBuf := make([]byte, 0, tfdt.Size())
 
 	w := bytes.NewBuffer(outBuf)
-	tfdt.Encode(w)
+	err = tfdt.Encode(w)
+	if err != nil {
+		t.Error(err)
+	}
 
 	writtenBytes := w.Bytes()
 
-	if bytes.Compare(byteData, writtenBytes) != 0 {
+	if !bytes.Equal(byteData, writtenBytes) {
 		t.Errorf("Encoded tfdt body not same as decoded")
 	}
-
 }

--- a/mp4/tfhd_test.go
+++ b/mp4/tfhd_test.go
@@ -25,7 +25,10 @@ func TestTfhd(t *testing.T) {
 
 	outbuf := &bytes.Buffer{}
 
-	tfhdRead.Encode(outbuf)
+	err = tfhdRead.Encode(outbuf)
+	if err != nil {
+		t.Error(err)
+	}
 
 	outRawBox := outbuf.Bytes()
 

--- a/mp4/tkhd_test.go
+++ b/mp4/tkhd_test.go
@@ -10,7 +10,10 @@ func TestTkhd(t *testing.T) {
 	var buf bytes.Buffer
 
 	tkhdCreated := CreateTkhd()
-	tkhdCreated.Encode(&buf)
+	err := tkhdCreated.Encode(&buf)
+	if err != nil {
+		t.Error(err)
+	}
 
 	if uint64(buf.Len()) != tkhdCreated.Size() {
 		t.Errorf("Mismatch bytes written %d not equal to size %d", buf.Len(), tkhdCreated.Size())

--- a/mp4/trun.go
+++ b/mp4/trun.go
@@ -18,7 +18,7 @@ type TrunBox struct {
 	samples          []*Sample
 }
 
-const dataOffsetPresentFlag = 0x01
+// const dataOffsetPresentFlag = 0x01
 const firstSamplePresentFlag = 0x02
 const sampleDurationPresentFlag = 0x100
 const sampleSizePresentFlag = 0x200

--- a/mp4/url.go
+++ b/mp4/url.go
@@ -36,7 +36,7 @@ func DecodeURLBox(hdr *boxHeader, startPos uint64, r io.Reader) (Box, error) {
 		Flags:    flags,
 		Location: location,
 	}
-	return u, nil
+	return u, err
 }
 
 // CreateURLBox - Create a self-referencing URL box

--- a/mp4/visualsampleentry.go
+++ b/mp4/visualsampleentry.go
@@ -167,7 +167,10 @@ func (a *VisualSampleEntryBox) Encode(w io.Writer) error {
 
 	// Next output child boxes in order
 	for _, child := range a.boxes {
-		child.Encode(w)
+		err = child.Encode(w)
+		if err != nil {
+			return err
+		}
 	}
 	return err
 }


### PR DESCRIPTION
```
bits/bits_benchmark_test.go:12:15: Error return value of `writer.Write` is not checked (errcheck)
		writer.Write(0xff, 8)
		           ^
mp4/avc.go:28:6: `isVideoNalu` is unused (deadcode)
func isVideoNalu(b []byte) bool {
     ^
mp4/box.go:191:6: `fixed16` is unused (deadcode)
func fixed16(bytes []byte) Fixed16 {
     ^
mp4/box.go:195:6: `putFixed16` is unused (deadcode)
func putFixed16(bytes []byte, i Fixed16) {
     ^
mp4/box.go:206:6: `fixed32` is unused (deadcode)
func fixed32(bytes []byte) Fixed32 {
     ^
mp4/box.go:210:6: `putFixed32` is unused (deadcode)
func putFixed32(bytes []byte, i Fixed32) {
     ^
mp4/trun.go:21:7: `dataOffsetPresentFlag` is unused (deadcode)
const dataOffsetPresentFlag = 0x01
      ^
mp4/audiosampleentry_test.go:14:12: Error return value of `ase.Encode` is not checked (errcheck)
	ase.Encode(&buf)
	         ^
mp4/audiosamplentry.go:144:15: Error return value of `child.Encode` is not checked (errcheck)
		child.Encode(w)
		           ^
mp4/avc.go:250:11: Error return value of `parseVUI` is not checked (errcheck)
		parseVUI(reader, &sps.VUI, true)
		       ^
mp4/avcdecoderconfigurationrecord.go:81:14: Error return value of `binary.Write` is not checked (errcheck)
	binary.Write(w, binary.BigEndian, configurationVersion)
	           ^
mp4/avcdecoderconfigurationrecord.go:82:14: Error return value of `binary.Write` is not checked (errcheck)
	binary.Write(w, binary.BigEndian, a.AVCProfileIndication)
	           ^
mp4/avcdecoderconfigurationrecord.go:83:14: Error return value of `binary.Write` is not checked (errcheck)
	binary.Write(w, binary.BigEndian, a.ProfileCompatibility)
	           ^
mp4/avcdecoderconfigurationrecord.go:91:10: Error return value of `w.Write` is not checked (errcheck)
		w.Write(sps)
		      ^
mp4/avcdecoderconfigurationrecord.go:98:10: Error return value of `w.Write` is not checked (errcheck)
		w.Write(pps)
		      ^
mp4/elng.go:52:9: Error return value of `w.Write` is not checked (errcheck)
	w.Write([]byte(b.Language))
	      ^
mp4/esds_test.go:17:15: Error return value of `esdsIn.Encode` is not checked (errcheck)
	esdsIn.Encode(&buf)
	            ^
mp4/initsegment_test.go:101:13: Error return value of `init.Encode` is not checked (errcheck)
	init.Encode(&buf)
	          ^
mp4/initsegment_test.go:119:13: Error return value of `init.Encode` is not checked (errcheck)
	init.Encode(ofd)
	          ^
mp4/mediasegment_test.go:49:27: Error return value of `.Encode` is not checked (errcheck)
	f.Segments[0].Styp.Encode(&buf)
	                        ^
mp4/mediasegment_test.go:51:14: Error return value of `frag.Encode` is not checked (errcheck)
		frag.Encode(&buf)
		          ^
mp4/mvhd_test.go:13:20: Error return value of `mvhdCreated.Encode` is not checked (errcheck)
	mvhdCreated.Encode(&buf)
	                 ^
mp4/tfdt_test.go:64:13: Error return value of `tfdt.Encode` is not checked (errcheck)
	tfdt.Encode(w)
	          ^
mp4/tfhd_test.go:28:17: Error return value of `tfhdRead.Encode` is not checked (errcheck)
	tfhdRead.Encode(outbuf)
	              ^
mp4/tkhd_test.go:13:20: Error return value of `tkhdCreated.Encode` is not checked (errcheck)
	tkhdCreated.Encode(&buf)
	                 ^
mp4/visualsampleentry.go:170:15: Error return value of `child.Encode` is not checked (errcheck)
		child.Encode(w)
		           ^
mp4/esds.go:99:2: ineffectual assignment to `size` (ineffassign)
	size, nrBytesRead := readSizeOfInstance(s)
	^
mp4/esds.go:107:2: ineffectual assignment to `size` (ineffassign)
	size, nrBytesRead = readSizeOfInstance(s)
	^
mp4/url.go:31:13: ineffectual assignment to `err` (ineffassign)
		location, err = s.ReadZeroTerminatedString()
		         ^
mp4/elng_test.go:41:5: S1030: should use buf.String() instead of string(buf.Bytes()) (gosimple)
	if string(buf.Bytes()) != elngString {
	  ^
mp4/esds_test.go:26:5: S1004: should use !bytes.Equal(decCfgOut, decCfg) instead (gosimple)
	if bytes.Compare(decCfgOut, decCfg) != 0 {
	  ^
mp4/mediasegment_test.go:59:5: S1004: should use !bytes.Equal(outFileContent, inFileContent) instead (gosimple)
	if bytes.Compare(outFileContent, inFileContent) != 0 {
	  ^
mp4/tfdt_test.go:68:5: S1004: should use !bytes.Equal(byteData, writtenBytes) instead (gosimple)
	if bytes.Compare(byteData, writtenBytes) != 0 {
	  ^
mp4/avc.go:194:50: S1019: should use make([]uint, numRefFramesInPicOrderCntCycle) instead (gosimple)
		sps.RefFramesInPicOrderCntCycle = make([]uint, numRefFramesInPicOrderCntCycle,
		                                              ^
mp4/initsegment_test.go:115:2: SA5001: should check returned error before deferring ofd.Close() (staticcheck)
	defer ofd.Close()
	^
cmd/mp4ff-pslister/main.go:35:2: SA5001: should check returned error before deferring ifd.Close() (staticcheck)
	defer ifd.Close()
	^
```