### PR TITLE
Better documentation of time scales and focus on single tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Test](https://github.com/edgeware/mp4ff/workflows/Test/badge.svg)
 
-MP4 media file parser and writer. Focused on fragmented files as used for streaming in DASH, MSS and HLS fMP4.
+MP4/ISOBMFF media file parser and writer. Focused on fragmented files as used for streaming in DASH, MSS and HLS fMP4.
 
 ## Library
 
@@ -94,6 +94,8 @@ These are
     segment durations.
 3. `segmenter` which takes a progressive mp4 file and creates init and media segments from it.
 
+## Stability
+The APIs should be fairly stable, but minor non-backwards-compatible tweaks may happen until version 1.
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ MP4 media file parser and writer. Focused on fragmented files as used for stream
 
 ## Library
 
-The library has functions for parsing (called Decode) and writing (Encocde).
+The library has functions for parsing (called Decode) and writing (Encode).
 mp4.File is a representation of a "File" which can be more or less complete, but should have some top layer boxes.
 
 It can include
@@ -25,6 +25,44 @@ The typical child boxes are exported so that one can write paths such as
 
 to access the (only) trun box in a fragment.
 
+The codec currently supported are AVC (=H.264) and AAC.
+
+When generating new content, the focus is on generating content following CMAF and DASH-IF guidelines.
+In particular, it means that the content is not multiplexed, and there is only one track in each
+moof box, and correspondingly a single `Traf` child box. The trakID is set to mp4.DefaultTrakID = 1.
+
+
+## Usage for creating new fragmented files
+
+A typical use case is to produce a series of segments start with an init segment and followed by media segments.
+
+The first step is to create an init segment. This is done in two steps and can be seen in
+`examples/initcreator:
+
+1. A call to `CreateEmptyInitSegment(timecale, mediatype, language)`
+2. Fill in the SampleDescriptor based on video parameter sets, or audio codec information.
+
+The second step is to start producing media segments. They should use the timescale that
+was set when creating the init segments. The timescales should be chosen so that the
+sample durations have exact values.
+
+A media segment contains one or more fragments, where each fragment has a moof and an mdat box.
+If all samples are availble before the segment is to be used, the easiest is to use a single
+fragment in each segment. Example code for this can be found in `examples/segmenter`.
+
+	seg := mp4.NewMediaSegment()
+	frag := mp4.CreateFragment(uint32(segNr), mp4.DefaultTrakID)
+	seg.AddFragment(frag)
+	for _, sample := range samples {
+		frag.AddSample(sample)
+	}
+
+Here the samples are instances of `mp4.SampleComplete` which are binary data together with
+timing information in the timescale of the trak and trun flags that should be set.
+All times have a timescale of the track which was set in the `mdhd` box when the init segment
+was created or read.
+
+
 ## Command Line Tools
 
 Some simple command line tools are available in `cmd`.
@@ -32,6 +70,13 @@ Some simple command line tools are available in `cmd`.
 ## Example code
 
 Example code is available in the `examples` directory.
+These are
+
+1. `initcreator` which creates typical init segments (ftyp + moov) for video and audio
+2. `resegmenter` which reads a segmented file (CMAF track) and resegments it with other
+    segment durations.
+3. `segmenter` which takes a progressive mp4 file and creates init and media segments from it.
+
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ A media segment contains one or more fragments, where each fragment has a moof a
 If all samples are available before the segment is to be used, one can use use a single
 fragment in each segment. Example code for this can be found in `examples/segmenter`.
 
-The high-level code to do that is to first create a slice of `SampleComplete` with the data needed.
+The high-level code to do that is to first create a slice of `FullSample` with the data needed.
 All times are in the track timescale set when creating the init segment and coded in the `mdhd` box.
 
-	mp4.SampleComplete{
+	mp4.FullSample{
 		Sample: mp4.Sample{
 	        Flags uint32 // Flag sync sample etc
 	        Dur   uint32 // Sample duration in mdhd timescale

--- a/examples/initcreator/main.go
+++ b/examples/initcreator/main.go
@@ -29,7 +29,8 @@ func writeVideoAVCInitSegment() error {
 	pps, _ := hex.DecodeString(pps1nalu)
 	ppsNALUs := [][]byte{pps}
 
-	init := mp4.CreateEmptyMP4Init(180000, "video", "und")
+	videoTimescale := uint32(180000)
+	init := mp4.CreateEmptyMP4Init(videoTimescale, "video", "und")
 	trak := init.Moov.Trak[0]
 	trak.SetAVCDescriptor("avc1", spsNALU, ppsNALUs)
 	width := trak.Mdia.Minf.Stbl.Stsd.AvcX.Width
@@ -37,28 +38,29 @@ func writeVideoAVCInitSegment() error {
 	if width != 1280 || height != 720 {
 		return errors.New("Did not get right width and height")
 	}
-	writeToFile(init, "video_init.cmfv")
-	return nil
+	err := writeToFile(init, "video_init.cmfv")
+	return err
 }
 
 func writeAudioAACInitSegment() error {
-	init := mp4.CreateEmptyMP4Init(48000, "audio", "en")
+	audioTimeScale := 48000
+	init := mp4.CreateEmptyMP4Init(uint32(audioTimeScale), "audio", "en")
 	trak := init.Moov.Trak[0]
-	err := trak.SetAACDescriptor(mp4.AAClc, 48000)
+	err := trak.SetAACDescriptor(mp4.AAClc, audioTimeScale)
 	if err != nil {
 		return err
 	}
-	writeToFile(init, "audio_init.cmfv")
-	return nil
+	err = writeToFile(init, "audio_init.cmfv")
+	return err
 }
 
 func writeToFile(init *mp4.InitSegment, filePath string) error {
 	// Next write to a file
 	ofd, err := os.Create(filePath)
-	defer ofd.Close()
 	if err != nil {
 		return err
 	}
+	defer ofd.Close()
 	err = init.Encode(ofd)
 	return err
 }

--- a/examples/resegmenter/main.go
+++ b/examples/resegmenter/main.go
@@ -46,7 +46,7 @@ func main() {
 	if *chunkDur <= 0 {
 		log.Fatalln("Chunk duration must be positive.")
 	}
-	newMp4 := Resegment(parsedMp4, uint64(*chunkDur))
+	newMp4, err := Resegment(parsedMp4, uint64(*chunkDur))
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/examples/resegmenter/main.go
+++ b/examples/resegmenter/main.go
@@ -25,33 +25,38 @@ func main() {
 
 	inFilePath := flag.String("f", "", "Required: Path to input file")
 	outFilePath := flag.String("o", "", "Required: Output file")
-	boundary := flag.Int("b", 0, "Required: chunk duration (ticks)")
+	chunkDur := flag.Int("b", 0, "Required: chunk duration (ticks)")
 
 	flag.Parse()
 
-	if *inFilePath == "" || *outFilePath == "" || *boundary == 0 {
+	if *inFilePath == "" || *outFilePath == "" || *chunkDur == 0 {
 		flag.Usage()
 		return
 	}
 
 	ifd, err := os.Open(*inFilePath)
-	defer ifd.Close()
 	if err != nil {
 		log.Fatalln(err)
 	}
+	defer ifd.Close()
 	parsedMp4, err := mp4.DecodeFile(ifd)
 	if err != nil {
 		log.Fatalln(err)
 	}
-	segBoundary := uint64(*boundary)
-	newMp4 := Resegment(parsedMp4, segBoundary)
+	if *chunkDur <= 0 {
+		log.Fatalln("Chunk duration must be positive.")
+	}
+	newMp4 := Resegment(parsedMp4, uint64(*chunkDur))
 	if err != nil {
 		log.Fatalln(err)
 	}
 	ofd, err := os.Create(*outFilePath)
-	defer ofd.Close()
 	if err != nil {
 		log.Fatalln(err)
 	}
-	newMp4.Encode(ofd)
+	defer ofd.Close()
+	err = newMp4.Encode(ofd)
+	if err != nil {
+		log.Fatalln(err)
+	}
 }

--- a/examples/resegmenter/resegment.go
+++ b/examples/resegmenter/resegment.go
@@ -16,7 +16,7 @@ func Resegment(in *mp4.File, chunkDur uint64) (*mp4.File, error) {
 
 	for _, iSeg := range in.Segments {
 		for _, iFrag := range iSeg.Fragments {
-			fSamples := iFrag.GetSampleData(in.Init.Moov.Mvex.Trex)
+			fSamples := iFrag.GetCompleteSamples(in.Init.Moov.Mvex.Trex)
 			iSamples = append(iSamples, fSamples...)
 		}
 	}

--- a/examples/resegmenter/resegment.go
+++ b/examples/resegmenter/resegment.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Resegment file into two segments
-func Resegment(in *mp4.File, boundary uint64) *mp4.File {
+func Resegment(in *mp4.File, chunkDur uint64) *mp4.File {
 	if !in.IsFragmented() {
 		log.Fatalf("Non-segmented input file not supported")
 	}
@@ -38,8 +38,8 @@ func Resegment(in *mp4.File, boundary uint64) *mp4.File {
 	}
 	nrSegments := 1
 	for nr, s := range iSamples {
-		if s.PresentationTime >= boundary && s.IsSync() && nrSegments == 1 {
-			fmt.Printf("Started second segment at %d\n", s.PresentationTime)
+		if s.PresentationTime() >= chunkDur && s.IsSync() && nrSegments == 1 {
+			fmt.Printf("Started second segment at %d\n", s.PresentationTime())
 			oFile.AddChildBox(inStyp, 0)
 			frag = mp4.CreateFragment(seqNr+1, trackID)
 			for _, box := range frag.Boxes() {
@@ -49,7 +49,7 @@ func Resegment(in *mp4.File, boundary uint64) *mp4.File {
 		}
 		frag.AddSample(s)
 		if s.IsSync() {
-			fmt.Printf("%4d DTS %d PTS %d\n", nr, s.DecodeTime, s.PresentationTime)
+			fmt.Printf("%4d DTS %d PTS %d\n", nr, s.DecodeTime, s.PresentationTime())
 		}
 
 	}

--- a/examples/resegmenter/resegment.go
+++ b/examples/resegmenter/resegment.go
@@ -12,11 +12,11 @@ func Resegment(in *mp4.File, chunkDur uint64) (*mp4.File, error) {
 	if !in.IsFragmented() {
 		log.Fatalf("Non-segmented input file not supported")
 	}
-	var iSamples []*mp4.SampleComplete
+	var iSamples []*mp4.FullSample
 
 	for _, iSeg := range in.Segments {
 		for _, iFrag := range iSeg.Fragments {
-			fSamples := iFrag.GetCompleteSamples(in.Init.Moov.Mvex.Trex)
+			fSamples := iFrag.GetFullSamples(in.Init.Moov.Mvex.Trex)
 			iSamples = append(iSamples, fSamples...)
 		}
 	}

--- a/examples/segmenter/main.go
+++ b/examples/segmenter/main.go
@@ -82,7 +82,10 @@ func main() {
 			}
 			newSegment = true
 			seg := mp4.NewMediaSegment()
-			frag := mp4.CreateFragment(uint32(segNr), mp4.DefaultTrakID)
+			frag, err := mp4.CreateFragment(uint32(segNr), mp4.DefaultTrakID)
+			if err != nil {
+				log.Fatalln(err)
+			}
 			seg.AddFragment(frag)
 			for _, sample := range samples {
 				frag.AddSample(sample)

--- a/examples/segmenter/main.go
+++ b/examples/segmenter/main.go
@@ -82,7 +82,7 @@ func main() {
 			}
 			newSegment = true
 			seg := mp4.NewMediaSegment()
-			frag := mp4.CreateFragment(uint32(segNr), 1)
+			frag := mp4.CreateFragment(uint32(segNr), mp4.DefaultTrakID)
 			seg.AddFragment(frag)
 			for _, sample := range samples {
 				frag.AddSample(sample)

--- a/examples/segmenter/segment.go
+++ b/examples/segmenter/segment.go
@@ -73,13 +73,13 @@ func (s *Segmenter) GetInitSegments() ([]*mp4.InitSegment, error) {
 	return inits, nil
 }
 
-// GetSamplesUntilTime - get list of SampleComplete from statSampleNr to endTimeMs
+// GetSamplesUntilTime - get slice of FullSample from statSampleNr to endTimeMs
 // The end point is currently not aligned with sync points as defined by the stss box
 // nextSampleNr is stored in track tr
-func (s *Segmenter) GetSamplesUntilTime(tr *Track, r io.ReadSeeker, startSampleNr, endTimeMs int) []*mp4.SampleComplete {
+func (s *Segmenter) GetSamplesUntilTime(tr *Track, r io.ReadSeeker, startSampleNr, endTimeMs int) []*mp4.FullSample {
 	stbl := tr.inTrak.Mdia.Minf.Stbl
 	nrSamples := stbl.Stsz.SampleNumber
-	var samples []*mp4.SampleComplete
+	var samples []*mp4.FullSample
 	for sampleNr := startSampleNr; sampleNr <= int(nrSamples); sampleNr++ {
 		chunkNr, sampleNrAtChunkStart, err := stbl.Stsc.ChunkNrFromSampleNr(sampleNr)
 		if err != nil {
@@ -122,7 +122,7 @@ func (s *Segmenter) GetSamplesUntilTime(tr *Track, r io.ReadSeeker, startSampleN
 		if isSync {
 			flags = mp4.SyncSampleFlags
 		}
-		sc := &mp4.SampleComplete{
+		sc := &mp4.FullSample{
 			Sample: mp4.Sample{
 				Flags: flags,
 				Size:  size,

--- a/examples/segmenter/segment.go
+++ b/examples/segmenter/segment.go
@@ -74,6 +74,7 @@ func (s *Segmenter) GetInitSegments() ([]*mp4.InitSegment, error) {
 }
 
 // GetSamplesUntilTime - get list of SampleComplete from statSampleNr to endTimeMs
+// The end point is currently not aligned with sync points as defined by the stss box
 // nextSampleNr is stored in track
 func (s *Segmenter) GetSamplesUntilTime(tr *Track, r io.ReadSeeker, startSampleNr, endTimeMs int) []*mp4.SampleComplete {
 	stbl := tr.inTrak.Mdia.Minf.Stbl

--- a/examples/segmenter/segment.go
+++ b/examples/segmenter/segment.go
@@ -75,7 +75,7 @@ func (s *Segmenter) GetInitSegments() ([]*mp4.InitSegment, error) {
 
 // GetSamplesUntilTime - get list of SampleComplete from statSampleNr to endTimeMs
 // The end point is currently not aligned with sync points as defined by the stss box
-// nextSampleNr is stored in track
+// nextSampleNr is stored in track tr
 func (s *Segmenter) GetSamplesUntilTime(tr *Track, r io.ReadSeeker, startSampleNr, endTimeMs int) []*mp4.SampleComplete {
 	stbl := tr.inTrak.Mdia.Minf.Stbl
 	nrSamples := stbl.Stsz.SampleNumber

--- a/examples/segmenter/segment.go
+++ b/examples/segmenter/segment.go
@@ -111,7 +111,7 @@ func (s *Segmenter) GetSamplesUntilTime(tr *Track, r io.ReadSeeker, startSampleN
 		if n != int(size) {
 			fmt.Printf("Read %d bytes instead of %d", n, size)
 		}
-		presTime := uint64(int64(decTime) + int64(cto))
+		//presTime := uint64(int64(decTime) + int64(cto))
 		//One can either segment on presentationTime or DecodeTime
 		//presTimeMs := presTime * 1000 / uint64(tr.timeScale)
 		decTimeMs := decTime * 1000 / uint64(tr.timeScale)
@@ -129,9 +129,8 @@ func (s *Segmenter) GetSamplesUntilTime(tr *Track, r io.ReadSeeker, startSampleN
 				Dur:   dur,
 				Cto:   cto,
 			},
-			DecodeTime:       decTime,
-			PresentationTime: presTime,
-			Data:             buf,
+			DecodeTime: decTime,
+			Data:       buf,
 		}
 
 		//fmt.Printf("Sample %d times %d %d, sync %v, offset %d, size %d\n", sampleNr, decTime, cto, isSync, offset, size)

--- a/mp4/README.md
+++ b/mp4/README.md
@@ -29,7 +29,7 @@ Container boxes like `moof`, have a list of all their children called `boxes`, b
 To handle media sample data there are two structures:
 
 1. `Sample` stores the sample information used in trun
-2. `SampleComplete` extends this with the sample binary data, and absolute decode and presentation times
+2. `FullSample` extends this with the sample binary data and absolute decode time
 
 A MediaSegment can be fragmented into multiple fragments by the method
 

--- a/mp4/README.md
+++ b/mp4/README.md
@@ -29,7 +29,7 @@ Container boxes like `moof`, have a list of all their children called `boxes`, b
 To handle media sample data there are two structures:
 
 1. `Sample` stores the sample information used in trun
-2. `SampleComplete` also carries a slice with the samples binary data, as well as decode and presentaiton time
+2. `SampleComplete` extends this with the sample binary data, and absolute decode and presentation times
 
 A MediaSegment can be fragmented into multiple fragments by the method
 

--- a/mp4/doc.go
+++ b/mp4/doc.go
@@ -2,11 +2,12 @@
 Package mp4 - library for parsing and writing MP4/ISOBMFF files with a focus on fragmented files.
 
 Most boxes have their own file named after the box four-letter name in the ISO/IEC 14996-12 standard,
-but in some cases, there may be multiple boxes that have the same content, and the code is then having a generic name like visualsampleentry.go.
+but in some cases, there may be multiple boxes that have the same content, and the code is then having a
+generic name like visualsampleentry.go.
 
 
-The Box interface is specified in box.go. It decodes box size and type in the box header and dispactches decode for each
-individual box depending on its type.
+The Box interface is specified in box.go. It decodes box size and type in the box header and
+dispatched decode for each individual box depending on its type.
 
 Implement a new box
 
@@ -20,7 +21,8 @@ FoooBox should then implement the Box{} interface methods:
      Size()
      Encode()
 
-but also its own decode method `DecodeFooo`, and register that method in the `decoders` map in `box.go`. For a simple example, look at the `prft` box in `prft.go`.
+but also its own decode method `DecodeFooo`, and register that method in the `decoders` map in `box.go`.
+For a simple example, look at the `prft` box in `prft.go`.
 
 Container Boxes
 
@@ -38,7 +40,7 @@ To handle media sample data there are two structures:
 
 1. `Sample` stores the sample information used in trun
 
-2. `SampleComplete` also carries a slice with the samples binary data, as well as decode and presentaiton time
+2. `FullSample` also carries a slice with the samples binary data as well as decode time
 
 Fragmenting segments
 

--- a/mp4/file.go
+++ b/mp4/file.go
@@ -16,15 +16,16 @@ import (
 //   moov : the movie box (meta-data)
 //   mdat : the media data (chunks and samples)
 //
-// If fragmented, the media data and its metadata is contained
+// If fragmented, the data is instead in Init and/or Segments.
+//
 // segments.
 type File struct {
-	Ftyp         *FtypBox
-	Moov         *MoovBox
-	Mdat         *MdatBox // Only used for non-fragmented boxes
-	boxes        []Box    // All top-level boxes in order
-	Init         *InitSegment
-	Segments     []*MediaSegment
+	Ftyp         *FtypBox        // Only used for non-fragmented files
+	Moov         *MoovBox        // Only used for non-fragmented files
+	Mdat         *MdatBox        // Only used for non-fragmented files
+	Init         *InitSegment    // Init data (ftyp + moov for fragmented file)
+	Segments     []*MediaSegment // Media segment
+	boxes        []Box           // All top-level boxes in order
 	isFragmented bool
 }
 

--- a/mp4/fragment.go
+++ b/mp4/fragment.go
@@ -102,7 +102,8 @@ func (f *Fragment) DumpSampleData(w io.Writer, trex *TrexBox) error {
 	samples := f.GetSampleData(trex)
 	for i, s := range samples {
 		if i < 9 {
-			fmt.Printf("%4d %8d %8d %6x %d %d\n", i, s.DecodeTime, s.PresentationTime, s.Flags, s.Size, len(s.Data))
+			fmt.Printf("%4d %8d %8d %6x %d %d\n", i, s.DecodeTime, s.PresentationTime(),
+				s.Flags, s.Size, len(s.Data))
 		}
 		toAnnexB(s.Data)
 		if w != nil {
@@ -119,7 +120,6 @@ func (f *Fragment) DumpSampleData(w io.Writer, trex *TrexBox) error {
 func (f *Fragment) Encode(w io.Writer) error {
 	trun := f.Moof.Traf.Trun
 	if trun.HasDataOffset() {
-		// TODO. This only works for one trun (one track)
 		// Make documentation or other stuff clear about that
 		trun.DataOffset = int32(f.Moof.Size() + 8)
 	}

--- a/mp4/fragment.go
+++ b/mp4/fragment.go
@@ -58,8 +58,8 @@ func (f *Fragment) AddChild(b Box) {
 	f.boxes = append(f.boxes, b)
 }
 
-// GetSampleData - Get all samples including data
-func (f *Fragment) GetSampleData(trex *TrexBox) []*SampleComplete {
+// GetCompleteSamples - Get complete samples including data and accumulated time
+func (f *Fragment) GetCompleteSamples(trex *TrexBox) []*SampleComplete {
 	moof := f.Moof
 	mdat := f.Mdat
 	seqNr := moof.Mfhd.SequenceNumber
@@ -84,7 +84,7 @@ func (f *Fragment) GetSampleData(trex *TrexBox) []*SampleComplete {
 	if offsetInMdat > mdatDataLength {
 		log.Fatalf("Offset in mdata beyond size")
 	}
-	samples := trun.GetSampleData(uint32(offsetInMdat), baseTime, f.Mdat)
+	samples := trun.GetCompleteSamples(uint32(offsetInMdat), baseTime, f.Mdat)
 	return samples
 }
 
@@ -102,7 +102,7 @@ func (f *Fragment) AddSample(s *SampleComplete) {
 
 // DumpSampleData - Get Sample data and print out
 func (f *Fragment) DumpSampleData(w io.Writer, trex *TrexBox) error {
-	samples := f.GetSampleData(trex)
+	samples := f.GetCompleteSamples(trex)
 	for i, s := range samples {
 		if i < 9 {
 			fmt.Printf("%4d %8d %8d %6x %d %d\n", i, s.DecodeTime, s.PresentationTime(),

--- a/mp4/fragment.go
+++ b/mp4/fragment.go
@@ -119,6 +119,8 @@ func (f *Fragment) DumpSampleData(w io.Writer, trex *TrexBox) error {
 func (f *Fragment) Encode(w io.Writer) error {
 	trun := f.Moof.Traf.Trun
 	if trun.HasDataOffset() {
+		// TODO. This only works for one trun (one track)
+		// Make documentation or other stuff clear about that
 		trun.DataOffset = int32(f.Moof.Size() + 8)
 	}
 	for _, b := range f.boxes {

--- a/mp4/initsegment.go
+++ b/mp4/initsegment.go
@@ -44,6 +44,7 @@ func (s *InitSegment) Encode(w io.Writer) error {
 }
 
 // CreateEmptyMP4Init - Create a one-track MP4 init segment with empty stsd box
+// The trak has trackID = 1. The irrelevant mdhd timescale is set to 90000 and duration = 0
 func CreateEmptyMP4Init(timeScale uint32, mediaType, language string) *InitSegment {
 	/* Build tree like
 	   moov
@@ -130,6 +131,7 @@ func CreateEmptyMP4Init(timeScale uint32, mediaType, language string) *InitSegme
 }
 
 // SetAVCDescriptor - Modify a TrakBox by adding AVC SampleDescriptor from one SPS and multiple PPS
+// Get width and height from SPS and fill into tkhd box.
 func (t *TrakBox) SetAVCDescriptor(sampleDescriptorType string, spsNALU []byte, ppsNALUs [][]byte) {
 	avcSPS, err := ParseSPSNALUnit(spsNALU)
 	if err != nil {

--- a/mp4/mdhd.go
+++ b/mp4/mdhd.go
@@ -20,8 +20,8 @@ const charOffset = 0x60 // According to Section 8.4.2.3 of 14496-12
 type MdhdBox struct {
 	Version          byte // Only version 0
 	Flags            uint32
-	CreationTime     uint64 // typically not set
-	ModificationTime uint64 // typically not set
+	CreationTime     uint64 // Typically not set
+	ModificationTime uint64 // Typically not set
 	Timescale        uint32 // Media timescale for this track
 	Duration         uint64 // Trak duration, 0 for fragmented files
 	Language         uint16 // Three-letter ISO-639-2/T language code

--- a/mp4/mdhd.go
+++ b/mp4/mdhd.go
@@ -15,16 +15,16 @@ const charOffset = 0x60 // According to Section 8.4.2.3 of 14496-12
 //
 // Contained in : Media Box (mdia)
 //
-// Timescale defines the timescale used for tracks.
+// Timescale defines the timescale used for this track.
 // Language is a ISO-639-2/T language code stored as 1bit padding + [3]int5
 type MdhdBox struct {
-	Version          byte
+	Version          byte // Only version 0
 	Flags            uint32
-	CreationTime     uint64
-	ModificationTime uint64
-	Timescale        uint32
-	Duration         uint64
-	Language         uint16
+	CreationTime     uint64 // typically not set
+	ModificationTime uint64 // typically not set
+	Timescale        uint32 // Media timescale for this track
+	Duration         uint64 // Trak duration, 0 for fragmented files
+	Language         uint16 // Three-letter ISO-639-2/T language code
 }
 
 // DecodeMdhd - Decode box

--- a/mp4/mediasegment.go
+++ b/mp4/mediasegment.go
@@ -55,7 +55,7 @@ func (s *MediaSegment) Fragmentify(timescale uint64, trex *TrexBox, duration uin
 
 	for _, inFrag := range inFragments {
 
-		samples := inFrag.GetCompleteSamples(trex)
+		samples := inFrag.GetFullSamples(trex)
 		for _, s := range samples {
 			if cumDur == 0 {
 				var err error

--- a/mp4/mediasegment.go
+++ b/mp4/mediasegment.go
@@ -58,7 +58,11 @@ func (s *MediaSegment) Fragmentify(timescale uint64, trex *TrexBox, duration uin
 		samples := inFrag.GetSampleData(trex)
 		for _, s := range samples {
 			if cumDur == 0 {
-				of = CreateFragment(inFrag.Moof.Mfhd.SequenceNumber, inFrag.Moof.Traf.Tfhd.TrackID)
+				var err error
+				of, err = CreateFragment(inFrag.Moof.Mfhd.SequenceNumber, inFrag.Moof.Traf.Tfhd.TrackID)
+				if err != nil {
+					return nil, err
+				}
 				outFragments = append(outFragments, of)
 			}
 			of.AddSample(s)

--- a/mp4/mediasegment.go
+++ b/mp4/mediasegment.go
@@ -55,7 +55,7 @@ func (s *MediaSegment) Fragmentify(timescale uint64, trex *TrexBox, duration uin
 
 	for _, inFrag := range inFragments {
 
-		samples := inFrag.GetSampleData(trex)
+		samples := inFrag.GetCompleteSamples(trex)
 		for _, s := range samples {
 			if cumDur == 0 {
 				var err error

--- a/mp4/moof.go
+++ b/mp4/moof.go
@@ -10,7 +10,7 @@ import (
 type MoofBox struct {
 	boxes    []Box
 	Mfhd     *MfhdBox
-	Traf     *TrafBox
+	Traf     *TrafBox // A single traf child box
 	StartPos uint64
 }
 
@@ -35,6 +35,10 @@ func (m *MoofBox) AddChild(b Box) {
 	case "mfhd":
 		m.Mfhd = b.(*MfhdBox)
 	case "traf":
+		if m.Traf != nil {
+			// There is already one track
+			panic("Multiple tracks not supported for segmented files")
+		}
 		m.Traf = b.(*TrafBox)
 	}
 	m.boxes = append(m.boxes, b)

--- a/mp4/mvhd.go
+++ b/mp4/mvhd.go
@@ -29,8 +29,8 @@ type MvhdBox struct {
 // CreateMvhd - create mvhd box with reasonable values
 func CreateMvhd() *MvhdBox {
 	return &MvhdBox{
-		Timescale:   90000,
-		NextTrackID: 2,
+		Timescale:   90000,      // Irrelevant since mdhd timescale is used
+		NextTrackID: 2,          // There will typically only be one track
 		Rate:        0x00010000, // This is 1.0
 		Volume:      0x0100,     // Full volume
 	}

--- a/mp4/sample.go
+++ b/mp4/sample.go
@@ -2,15 +2,15 @@ package mp4
 
 import "encoding/binary"
 
-// Sample - sample as used in trun box
+// Sample - sample as used in trun box (mdhd timescale)
 type Sample struct {
-	Flags uint32
-	Dur   uint32
-	Size  uint32
-	Cto   int32
+	Flags uint32 // Flag sync sample etc
+	Dur   uint32 // Sample duration in mdhd timescale
+	Size  uint32 // Size of sample data
+	Cto   int32  // Signed composition time offset
 }
 
-// NewSample - create Sample
+// NewSample - create Sample with trun data
 func NewSample(flags uint32, dur uint32, size uint32, cto int32) *Sample {
 	return &Sample{
 		Flags: flags,
@@ -26,12 +26,12 @@ func (s *Sample) IsSync() bool {
 	return !decFlags.SampleIsNonSync && (decFlags.SampleDependsOn == 2)
 }
 
-//SampleComplete - include times and data. Times in track timescale
+//SampleComplete - include accumulated time and data. Times mdhd timescale
 type SampleComplete struct {
 	Sample
-	DecodeTime       uint64
-	PresentationTime uint64
-	Data             []byte
+	DecodeTime       uint64 // Accumulated decode time in mdhd timescale. Used in tfdt encode
+	PresentationTime uint64 // DecodeTime + compositionTimeOffset in mdhd timescale
+	Data             []byte // Sample data
 }
 
 func toAnnexB(videoSample []byte) {

--- a/mp4/sample.go
+++ b/mp4/sample.go
@@ -26,15 +26,15 @@ func (s *Sample) IsSync() bool {
 	return !decFlags.SampleIsNonSync && (decFlags.SampleDependsOn == 2)
 }
 
-// SampleComplete - include accumulated time and data. Times in mdhd timescale
-type SampleComplete struct {
+// FullSample - include accumulated time and data. Times in mdhd timescale
+type FullSample struct {
 	Sample
 	DecodeTime uint64 // Absolute decode time (offset + accumulated sample Dur)
 	Data       []byte // Sample data
 }
 
 // PresentationTime - DecodeTime displaced by composition time offset (possibly negative)
-func (s *SampleComplete) PresentationTime() uint64 {
+func (s *FullSample) PresentationTime() uint64 {
 	p := int64(s.DecodeTime) + int64(s.Cto)
 	if p < 0 {
 		p = 0 // Extraordinary case. Clip it to 0.

--- a/mp4/tkhd.go
+++ b/mp4/tkhd.go
@@ -9,7 +9,7 @@ import (
 // TkhdBox - Track Header Box (tkhd - mandatory)
 //
 // This box describes the track. Duration is measured in time units (according to the time scale
-// defined in the movie header box).
+// defined in the movie header box). Duration is 0 for fragmented files.
 //
 // Volume (relevant for audio tracks) is a fixed point number (8 bits + 8 bits). Full volume is 1.0.
 // Width and Height (relevant for video tracks) are fixed point numbers (16 bits + 16 bits).
@@ -31,8 +31,8 @@ type TkhdBox struct {
 func CreateTkhd() *TkhdBox {
 	return &TkhdBox{
 		Version: 0,
-		Flags:   0x000007, // Enabled, inMovie, inPreview set
-		TrackID: 1,
+		Flags:   0x000007,      // Enabled, inMovie, inPreview set
+		TrackID: DefaultTrakID, // Typically just have one track
 	}
 }
 

--- a/mp4/traf.go
+++ b/mp4/traf.go
@@ -34,6 +34,9 @@ func (t *TrafBox) AddChild(b Box) {
 	case "tfdt":
 		t.Tfdt = b.(*TfdtBox)
 	case "trun":
+		if t.Trun != nil {
+			panic("There is already one trun box. Multiple trun boxes not supported")
+		}
 		t.Trun = b.(*TrunBox)
 	default:
 	}

--- a/mp4/trak.go
+++ b/mp4/trak.go
@@ -2,6 +2,9 @@ package mp4
 
 import "io"
 
+// DefaultTrakID - trakID used when generating new fragmented content
+const DefaultTrakID = 1
+
 // TrakBox - Track Box (tkhd - mandatory)
 //
 // Contained in : Movie Box (moov)

--- a/mp4/trun.go
+++ b/mp4/trun.go
@@ -228,19 +228,18 @@ func (t *TrunBox) Encode(w io.Writer) error {
 	return err
 }
 
-// GetCompleteSamples - get all sample data including accumulated time and binary media
-
+// GetFullSamples - get all sample data including accumulated time and binary media
 // baseOffset is offset in mdat (normally 8)
 // baseTime is offset in track timescale (from mfhd)
 // To fill missing individual values from thd and trex defaults, call AddSampleDefaultValues() before this call
-func (t *TrunBox) GetCompleteSamples(baseOffset uint32, baseTime uint64, mdat *MdatBox) []*SampleComplete {
-	samples := make([]*SampleComplete, 0, t.SampleCount())
+func (t *TrunBox) GetFullSamples(baseOffset uint32, baseTime uint64, mdat *MdatBox) []*FullSample {
+	samples := make([]*FullSample, 0, t.SampleCount())
 	var accDur uint64 = 0
 	offset := baseOffset
 	for _, s := range t.samples {
 		dTime := baseTime + accDur
 
-		newSample := &SampleComplete{
+		newSample := &FullSample{
 			Sample:     *s,
 			DecodeTime: dTime,
 			Data:       mdat.Data[offset : offset+s.Size],
@@ -258,13 +257,13 @@ func (t *TrunBox) GetSamples() []*Sample {
 	return t.samples
 }
 
-// AddCompleteSample - add sample from a complete sample
-func (t *TrunBox) AddCompleteSample(s *SampleComplete) {
+// AddFullSample - add Sample part of FullSample
+func (t *TrunBox) AddFullSample(s *FullSample) {
 	t.samples = append(t.samples, &s.Sample)
 	t.sampleCount++
 }
 
-// AddSample - add a sample
+// AddSample - add a Sample
 func (t *TrunBox) AddSample(s *Sample) {
 	t.samples = append(t.samples, s)
 	t.sampleCount++

--- a/mp4/trun.go
+++ b/mp4/trun.go
@@ -127,7 +127,7 @@ func (t *TrunBox) SampleCount() uint32 {
 	return t.sampleCount
 }
 
-// HasDataOffset - interpted dataOffsetPresent flag
+// HasDataOffset - interpreted dataOffsetPresent flag
 func (t *TrunBox) HasDataOffset() bool {
 	return t.flags&0x01 != 0
 }
@@ -228,8 +228,12 @@ func (t *TrunBox) Encode(w io.Writer) error {
 	return err
 }
 
-// GetSampleData - return list of Samples. baseOffset is offset in mdat
-func (t *TrunBox) GetSampleData(baseOffset uint32, baseTime uint64, mdat *MdatBox) []*SampleComplete {
+// GetCompleteSamples - get all sample data including accumulated time and binary media
+
+// baseOffset is offset in mdat (normally 8)
+// baseTime is offset in track timescale (from mfhd)
+// To fill missing individual values from thd and trex defaults, call AddSampleDefaultValues() before this call
+func (t *TrunBox) GetCompleteSamples(baseOffset uint32, baseTime uint64, mdat *MdatBox) []*SampleComplete {
 	samples := make([]*SampleComplete, 0, t.SampleCount())
 	var accDur uint64 = 0
 	offset := baseOffset
@@ -246,6 +250,12 @@ func (t *TrunBox) GetSampleData(baseOffset uint32, baseTime uint64, mdat *MdatBo
 		offset += s.Size
 	}
 	return samples
+}
+
+// GetSamples - get all trun sample data
+// To fill missing individual values from thd and trex defaults, call AddSampleDefaultValues() before this call
+func (t *TrunBox) GetSamples() []*Sample {
+	return t.samples
 }
 
 // AddCompleteSample - add sample from a complete sample

--- a/mp4/trun.go
+++ b/mp4/trun.go
@@ -235,13 +235,11 @@ func (t *TrunBox) GetSampleData(baseOffset uint32, baseTime uint64, mdat *MdatBo
 	offset := baseOffset
 	for _, s := range t.samples {
 		dTime := baseTime + accDur
-		pTime := uint64(int64(dTime) + int64(s.Cto))
 
 		newSample := &SampleComplete{
-			Sample:           *s,
-			DecodeTime:       dTime,
-			PresentationTime: pTime,
-			Data:             mdat.Data[offset : offset+s.Size],
+			Sample:     *s,
+			DecodeTime: dTime,
+			Data:       mdat.Data[offset : offset+s.Size],
 		}
 		samples = append(samples, newSample)
 		accDur += uint64(s.Dur)


### PR DESCRIPTION
Enhanced documentation on sample data, time scales, and some checks that multiple tracks are not used in media tracks, since not supported.

Triggered by issue #8.

Changed SampleComplete PresentationTime into a method.
Also renamed SampleComplete to FullSample and some other API changes.