### PR TITLE
Dump method added to Box interface together with minimal implementations

### DIFF
--- a/examples/tree/main.go
+++ b/examples/tree/main.go
@@ -1,0 +1,34 @@
+// mp4ff-tree print a tree of the box structure of a file.
+//
+//   Usage:
+//
+//    mp4ff-tree <input.mp4>
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"github.com/edgeware/mp4ff/mp4"
+)
+
+func main() {
+
+	inFilePath := flag.String("i", "", "Required: Path to input file")
+
+	flag.Parse()
+
+	if *inFilePath == "" {
+		flag.Usage()
+		return
+	}
+
+	ifd, err := os.Open(*inFilePath)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer ifd.Close()
+	parsedMp4, err := mp4.DecodeFile(ifd)
+	parsedMp4.Dump(os.Stdout, "  ")
+}

--- a/mp4/README.md
+++ b/mp4/README.md
@@ -19,10 +19,11 @@ Fooo should then implement the Box interface methods:
      Type()
      Size()
      Encode()
+     Dump()
 
 but also its own decode method `DecodeFooo`, and register that method in the `decoders` map in `box.go`. For a simple example, look at the `prft` box in `prft.go`.
 
-Container boxes like `moof`, have a list of all their children called `boxes`, but also direct pointers to the children with appropriate names, like `Mfhd` and `Traf`. This makes it easy to chain box paths to reach an element like a TfhdBox like
+Container boxes like `moof`, have a list of all their children called `boxes`, but also direct pointers to the children with appropriate names, like `Mfhd` and `Traf`. This makes it easy to chain box paths to reach an element like a TfhdBox as
 
     file.Moof.Traf.Tfhd
 

--- a/mp4/audiosamplentry.go
+++ b/mp4/audiosamplentry.go
@@ -2,6 +2,7 @@ package mp4
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 )
@@ -146,5 +147,10 @@ func (a *AudioSampleEntryBox) Encode(w io.Writer) error {
 			return err
 		}
 	}
+	return err
+}
+
+func (a *AudioSampleEntryBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, a.Type(), a.Size())
 	return err
 }

--- a/mp4/avcc.go
+++ b/mp4/avcc.go
@@ -1,6 +1,7 @@
 package mp4
 
 import (
+	"fmt"
 	"io"
 )
 
@@ -58,4 +59,9 @@ func (a *AvcCBox) Encode(w io.Writer) error {
 		return err
 	}
 	return a.AVCDecConfRec.Encode(w)
+}
+
+func (a *AvcCBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, a.Type(), a.Size())
+	return err
 }

--- a/mp4/box.go
+++ b/mp4/box.go
@@ -145,6 +145,7 @@ type Box interface {
 	Type() string
 	Size() uint64
 	Encode(w io.Writer) error
+	Dump(w io.Writer, indent, indentStep string) error
 }
 
 // BoxDecoder is function signature of the Box Decode method

--- a/mp4/btrt.go
+++ b/mp4/btrt.go
@@ -2,6 +2,7 @@ package mp4
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 	"io/ioutil"
 )
@@ -58,5 +59,10 @@ func (b *BtrtBox) Encode(w io.Writer) error {
 	write(b.MaxBitrate)
 	write(b.AvgBitrate)
 
+	return err
+}
+
+func (b *BtrtBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, b.Type(), b.Size())
 	return err
 }

--- a/mp4/container.go
+++ b/mp4/container.go
@@ -1,6 +1,7 @@
 package mp4
 
 import (
+	"fmt"
 	"io"
 )
 
@@ -10,6 +11,7 @@ type ContainerBox interface {
 	Size() uint64
 	Encode(w io.Writer) error
 	GetChildren() []Box
+	Dump(w io.Writer, indent, indentStep string) error
 }
 
 func containerSize(boxes []Box) uint64 {
@@ -55,4 +57,18 @@ func EncodeContainer(c ContainerBox, w io.Writer) error {
 		}
 	}
 	return nil
+}
+
+func DumpContainer(c ContainerBox, w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, c.Type(), c.Size())
+	if err != nil {
+		return err
+	}
+	for _, child := range c.GetChildren() {
+		err := child.Dump(w, indent+indentStep, indentStep)
+		if err != nil {
+			return err
+		}
+	}
+	return err
 }

--- a/mp4/ctts.go
+++ b/mp4/ctts.go
@@ -2,6 +2,7 @@ package mp4
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 	"io/ioutil"
 )
@@ -82,4 +83,9 @@ func (b *CttsBox) GetCompositionTimeOffset(sampleNr uint32) int32 {
 		i++
 	}
 	return 0 // Should never get here, but a harmless return value
+}
+
+func (b *CttsBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, b.Type(), b.Size())
+	return err
 }

--- a/mp4/dinf.go
+++ b/mp4/dinf.go
@@ -54,3 +54,7 @@ func (d *DinfBox) GetChildren() []Box {
 func (d *DinfBox) Encode(w io.Writer) error {
 	return EncodeContainer(d, w)
 }
+
+func (d *DinfBox) Dump(w io.Writer, indent, indentStep string) error {
+	return DumpContainer(d, w, indent, indentStep)
+}

--- a/mp4/dref.go
+++ b/mp4/dref.go
@@ -2,6 +2,7 @@ package mp4
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 )
 
@@ -95,5 +96,10 @@ func (d *DrefBox) Encode(w io.Writer) error {
 			return err
 		}
 	}
+	return err
+}
+
+func (d *DrefBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, d.Type(), d.Size())
 	return err
 }

--- a/mp4/edts.go
+++ b/mp4/edts.go
@@ -1,6 +1,8 @@
 package mp4
 
-import "io"
+import (
+	"io"
+)
 
 // EdtsBox - Edit Box (edts - optional)
 //
@@ -41,13 +43,6 @@ func (b *EdtsBox) Size() uint64 {
 	return containerSize(b.Children)
 }
 
-// Dump - print box info
-func (b *EdtsBox) Dump() {
-	for _, elst := range b.Elst {
-		elst.Dump()
-	}
-}
-
 // GetChildren - list of child boxes
 func (b *EdtsBox) GetChildren() []Box {
 	return b.Children
@@ -56,4 +51,8 @@ func (b *EdtsBox) GetChildren() []Box {
 // Encode - write edts container to w
 func (b *EdtsBox) Encode(w io.Writer) error {
 	return EncodeContainer(b, w)
+}
+
+func (b *EdtsBox) Dump(w io.Writer, indent, indentStep string) error {
+	return DumpContainer(b, w, indent, indentStep)
 }

--- a/mp4/elng.go
+++ b/mp4/elng.go
@@ -38,11 +38,6 @@ func (b *ElngBox) Size() uint64 {
 	return uint64(boxHeaderSize + len(b.Language) + 1)
 }
 
-// Dump - print box info
-func (b *ElngBox) Dump() {
-	fmt.Println("Language: ", b.Language)
-}
-
 // Encode - write box to w
 func (b *ElngBox) Encode(w io.Writer) error {
 	err := EncodeHeader(b, w)
@@ -54,5 +49,11 @@ func (b *ElngBox) Encode(w io.Writer) error {
 		return err
 	}
 	_, err = w.Write([]byte{0})
+	return err
+}
+
+func (b *ElngBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n%s - Language: %s\n", indent,
+		b.Type(), b.Size(), indent, b.Language)
 	return err
 }

--- a/mp4/elst.go
+++ b/mp4/elst.go
@@ -71,14 +71,6 @@ func (b *ElstBox) Size() uint64 {
 	return uint64(boxHeaderSize + 8 + len(b.SegmentDuration)*12) // m.Version == 0
 }
 
-// Dump - print box info
-func (b *ElstBox) Dump() {
-	fmt.Println("Segment Duration:")
-	for i, d := range b.SegmentDuration {
-		fmt.Printf(" #%d: %d units\n", i, d)
-	}
-}
-
 // Encode - write box to w
 func (b *ElstBox) Encode(w io.Writer) error {
 	err := EncodeHeader(b, w)
@@ -108,4 +100,19 @@ func (b *ElstBox) Encode(w io.Writer) error {
 
 	_, err = w.Write(buf)
 	return err
+}
+
+func (b *ElstBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n%s - Segment durations:\n",
+		indent, b.Type(), b.Size(), indent)
+	if err != nil {
+		return err
+	}
+	for i, d := range b.SegmentDuration {
+		_, err := fmt.Fprintf(w, "%s - #%d: %d units\n", indent, i, d)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/mp4/esds.go
+++ b/mp4/esds.go
@@ -2,6 +2,7 @@ package mp4
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 )
@@ -195,5 +196,10 @@ func (e *EsdsBox) Encode(w io.Writer) error {
 	sw.WriteUint8(e.SLConfigValue) // Constant
 
 	_, err = w.Write(buf)
+	return err
+}
+
+func (e *EsdsBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, e.Type(), e.Size())
 	return err
 }

--- a/mp4/fragment.go
+++ b/mp4/fragment.go
@@ -131,6 +131,17 @@ func (f *Fragment) Encode(w io.Writer) error {
 	return nil
 }
 
+// Dump - write box tree with indent for each level
+func (f *Fragment) Dump(w io.Writer, indent string) error {
+	for _, box := range f.Children {
+		err := box.Dump(w, "", indent)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // GetChildren - return children boxes
 func (f *Fragment) GetChildren() []Box {
 	return f.Children

--- a/mp4/free.go
+++ b/mp4/free.go
@@ -1,6 +1,7 @@
 package mp4
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 )
@@ -36,5 +37,10 @@ func (b *FreeBox) Encode(w io.Writer) error {
 		return err
 	}
 	_, err = w.Write(b.notDecoded)
+	return err
+}
+
+func (b *FreeBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, b.Type(), b.Size())
 	return err
 }

--- a/mp4/ftyp.go
+++ b/mp4/ftyp.go
@@ -51,11 +51,6 @@ func (b *FtypBox) Size() uint64 {
 	return uint64(boxHeaderSize + 8 + 4*len(b.CompatibleBrands))
 }
 
-// Dump - print box info
-func (b *FtypBox) Dump() {
-	fmt.Printf("File Type: %s\n", b.MajorBrand)
-}
-
 // Encode - write box to w
 func (b *FtypBox) Encode(w io.Writer) error {
 	err := EncodeHeader(b, w)
@@ -69,5 +64,11 @@ func (b *FtypBox) Encode(w io.Writer) error {
 		strtobuf(buf[8+i*4:], c, 4)
 	}
 	_, err = w.Write(buf)
+	return err
+}
+
+func (b *FtypBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n%s - Major Brand: %s\n",
+		indent, b.Type(), b.Size(), indent, b.MajorBrand)
 	return err
 }

--- a/mp4/hdlr.go
+++ b/mp4/hdlr.go
@@ -33,7 +33,7 @@ func CreateHdlr(mediaType string) (*HdlrBox, error) {
 		hdlr.HandlerType = "soun"
 		hdlr.Name = "Edgeware Audio Handler"
 	default:
-		return nil, fmt.Errorf("Unkown mediTyps %s", mediaType)
+		return nil, fmt.Errorf("Unkown mediaType %s", mediaType)
 	}
 	return hdlr, nil
 }
@@ -78,5 +78,11 @@ func (b *HdlrBox) Encode(w io.Writer) error {
 	strtobuf(buf[8:], b.HandlerType, 4)
 	strtobuf(buf[24:], b.Name, len(b.Name))
 	_, err = w.Write(buf)
+	return err
+}
+
+func (b *HdlrBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n%s - Handler type: %s\n%s - Handler name: %s\n",
+		indent, b.Type(), b.Size(), indent, b.HandlerType, indent, b.Name)
 	return err
 }

--- a/mp4/initsegment.go
+++ b/mp4/initsegment.go
@@ -43,6 +43,17 @@ func (s *InitSegment) Encode(w io.Writer) error {
 	return nil
 }
 
+// Dump - write box tree with indent for each level
+func (i *InitSegment) Dump(w io.Writer, indent string) error {
+	for _, box := range i.Children {
+		err := box.Dump(w, "", indent)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // CreateEmptyMP4Init - Create a one-track MP4 init segment with empty stsd box
 // The trak has trackID = 1. The irrelevant mdhd timescale is set to 90000 and duration = 0
 func CreateEmptyMP4Init(timeScale uint32, mediaType, language string) *InitSegment {

--- a/mp4/mdat.go
+++ b/mp4/mdat.go
@@ -2,6 +2,7 @@ package mp4
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 	"io/ioutil"
 )
@@ -51,5 +52,10 @@ func (m *MdatBox) Encode(w io.Writer) error {
 		}
 	}
 	_, err = w.Write(m.Data)
+	return err
+}
+
+func (m *MdatBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, m.Type(), m.Size())
 	return err
 }

--- a/mp4/mdhd.go
+++ b/mp4/mdhd.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"time"
 )
 
 const charOffset = 0x60 // According to Section 8.4.2.3 of 14496-12
@@ -90,12 +89,6 @@ func (m *MdhdBox) Size() uint64 {
 	return 32 // m.Version = 0
 }
 
-// Dump - print box info
-func (m *MdhdBox) Dump() {
-	fmt.Printf("Media Header:\n Timescale: %d units/sec\n Duration: %d units (%s)\n",
-		m.Timescale, m.Duration, time.Duration(m.Duration/uint64(m.Timescale))*time.Second)
-}
-
 // Encode - write box to w
 func (m *MdhdBox) Encode(w io.Writer) error {
 	err := EncodeHeader(m, w)
@@ -121,5 +114,11 @@ func (m *MdhdBox) Encode(w io.Writer) error {
 	sw.WriteUint16(m.Language)
 	sw.WriteUint16(0)
 	_, err = w.Write(buf)
+	return err
+}
+
+func (m *MdhdBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n%s - Timescale: %d\n%s - Language: %s\n",
+		indent, m.Type(), m.Size(), indent, m.Timescale, indent, m.GetLanguage())
 	return err
 }

--- a/mp4/mdia.go
+++ b/mp4/mdia.go
@@ -61,14 +61,6 @@ func (m *MdiaBox) Size() uint64 {
 	return containerSize(m.Children)
 }
 
-// Dump - print data of lower levels
-func (m *MdiaBox) Dump() {
-	m.Mdhd.Dump()
-	if m.Minf != nil {
-		m.Minf.Dump()
-	}
-}
-
 // GetChildren - list of child boxes
 func (m *MdiaBox) GetChildren() []Box {
 	return m.Children
@@ -77,4 +69,8 @@ func (m *MdiaBox) GetChildren() []Box {
 // Encode - write mdia container to w
 func (m *MdiaBox) Encode(w io.Writer) error {
 	return EncodeContainer(m, w)
+}
+
+func (m *MdiaBox) Dump(w io.Writer, indent, indentStep string) error {
+	return DumpContainer(m, w, indent, indentStep)
 }

--- a/mp4/mediasegment.go
+++ b/mp4/mediasegment.go
@@ -45,6 +45,23 @@ func (s *MediaSegment) Encode(w io.Writer) error {
 	return nil
 }
 
+// Dump - write box tree with indent for each level
+func (m *MediaSegment) Dump(w io.Writer, indent string) error {
+	if m.Styp != nil {
+		err := m.Styp.Dump(w, "", indent)
+		if err != nil {
+			return err
+		}
+	}
+	for _, f := range m.Fragments {
+		err := f.Dump(w, indent)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Fragmentify - Split into multiple fragments. Assume single mdat and trun for now
 func (s *MediaSegment) Fragmentify(timescale uint64, trex *TrexBox, duration uint32) ([]*Fragment, error) {
 	inFragments := s.Fragments

--- a/mp4/mfhd.go
+++ b/mp4/mfhd.go
@@ -52,11 +52,6 @@ func (m *MfhdBox) Size() uint64 {
 	return boxHeaderSize + 8
 }
 
-// Dump - print box info
-func (m *MfhdBox) Dump() {
-	fmt.Printf("Media Fragment Header:\n Sequence Number: %d\n", m.SequenceNumber)
-}
-
 // Encode - write box to w
 func (m *MfhdBox) Encode(w io.Writer) error {
 	err := EncodeHeader(m, w)
@@ -69,5 +64,11 @@ func (m *MfhdBox) Encode(w io.Writer) error {
 	sw.WriteUint32(versionAndFlags)
 	sw.WriteUint32(m.SequenceNumber)
 	_, err = w.Write(buf)
+	return err
+}
+
+func (m *MfhdBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n%s - Sequence number: %d\n",
+		indent, m.Type(), m.Size(), indent, m.SequenceNumber)
 	return err
 }

--- a/mp4/minf.go
+++ b/mp4/minf.go
@@ -59,11 +59,6 @@ func (m *MinfBox) Size() uint64 {
 	return containerSize(m.Children)
 }
 
-// Dump - print box info
-func (m *MinfBox) Dump() {
-	m.Stbl.Dump()
-}
-
 // GetChildren - list of child boxes
 func (m *MinfBox) GetChildren() []Box {
 	return m.Children
@@ -72,4 +67,8 @@ func (m *MinfBox) GetChildren() []Box {
 // Encode - write minf container to w
 func (m *MinfBox) Encode(w io.Writer) error {
 	return EncodeContainer(m, w)
+}
+
+func (m *MinfBox) Dump(w io.Writer, indent, indentStep string) error {
+	return DumpContainer(m, w, indent, indentStep)
 }

--- a/mp4/moof.go
+++ b/mp4/moof.go
@@ -88,3 +88,7 @@ func (m *MoofBox) Encode(w io.Writer) error {
 func (m *MoofBox) GetChildren() []Box {
 	return m.Children
 }
+
+func (m *MoofBox) Dump(w io.Writer, indent, indentStep string) error {
+	return DumpContainer(m, w, indent, indentStep)
+}

--- a/mp4/moov.go
+++ b/mp4/moov.go
@@ -1,7 +1,6 @@
 package mp4
 
 import (
-	"fmt"
 	"io"
 )
 
@@ -57,15 +56,6 @@ func (m *MoovBox) Size() uint64 {
 	return containerSize(m.Children)
 }
 
-// Dump - print box info
-func (m *MoovBox) Dump() {
-	m.Mvhd.Dump()
-	for i, t := range m.Trak {
-		fmt.Println("Track", i)
-		t.Dump()
-	}
-}
-
 // GetChildren - list of child boxes
 func (m *MoovBox) GetChildren() []Box {
 	return m.Children
@@ -74,4 +64,8 @@ func (m *MoovBox) GetChildren() []Box {
 // Encode - write moov container to w
 func (m *MoovBox) Encode(w io.Writer) error {
 	return EncodeContainer(m, w)
+}
+
+func (m *MoovBox) Dump(w io.Writer, indent, indentStep string) error {
+	return DumpContainer(m, w, indent, indentStep)
 }

--- a/mp4/mvex.go
+++ b/mp4/mvex.go
@@ -60,3 +60,7 @@ func (t *MvexBox) GetChildren() []Box {
 func (m *MvexBox) Encode(w io.Writer) error {
 	return EncodeContainer(m, w)
 }
+
+func (m *MvexBox) Dump(w io.Writer, indent, indentStep string) error {
+	return DumpContainer(m, w, indent, indentStep)
+}

--- a/mp4/mvhd.go
+++ b/mp4/mvhd.go
@@ -84,11 +84,6 @@ func (b *MvhdBox) Size() uint64 {
 	return 12 + 80 + 16 // Full header + variable part + fixed part
 }
 
-// Dump - write box details
-func (b *MvhdBox) Dump() {
-	fmt.Printf("Movie Header:\n Timescale: %d units/sec", b.Timescale)
-}
-
 // Encode - write box to w
 func (b *MvhdBox) Encode(w io.Writer) error {
 	err := EncodeHeader(b, w)
@@ -119,5 +114,10 @@ func (b *MvhdBox) Encode(w io.Writer) error {
 	sw.WriteInt32(b.NextTrackID)
 
 	_, err = w.Write(buf)
+	return err
+}
+
+func (b *MvhdBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, b.Type(), b.Size())
 	return err
 }

--- a/mp4/prft.go
+++ b/mp4/prft.go
@@ -1,6 +1,7 @@
 package mp4
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 )
@@ -79,5 +80,10 @@ func (p *PrftBox) Encode(w io.Writer) error {
 		sw.WriteUint64(p.MediaTime)
 	}
 	_, err = w.Write(buf)
+	return err
+}
+
+func (p *PrftBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, p.Type(), p.Size())
 	return err
 }

--- a/mp4/senc.go
+++ b/mp4/senc.go
@@ -2,6 +2,7 @@ package mp4
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 )
 
@@ -40,12 +41,12 @@ func DecodeSenc(hdr *boxHeader, startPos uint64, r io.Reader) (Box, error) {
 	if err != nil {
 		return nil, err
 	}
-	stsd := &SencBox{
+	senc := &SencBox{
 		Version:     byte(versionAndFlags >> 24),
 		Flags:       versionAndFlags & flagsMask,
 		SampleCount: sampleCount,
 	}
-	return stsd, nil
+	return senc, nil
 }
 
 // Type - box-specific type
@@ -74,4 +75,9 @@ func (s *SencBox) Encode(w io.Writer) error {
 		return err
 	}
 	return nil
+}
+
+func (s *SencBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, s.Type(), s.Size())
+	return err
 }

--- a/mp4/smhd.go
+++ b/mp4/smhd.go
@@ -1,6 +1,7 @@
 package mp4
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 )
@@ -58,5 +59,10 @@ func (b *SmhdBox) Encode(w io.Writer) error {
 	sw.WriteUint16(b.Balance)
 	sw.WriteUint16(0) // Reserved
 	_, err = w.Write(buf)
+	return err
+}
+
+func (b *SmhdBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, b.Type(), b.Size())
 	return err
 }

--- a/mp4/stbl.go
+++ b/mp4/stbl.go
@@ -70,25 +70,6 @@ func (s *StblBox) Size() uint64 {
 	return containerSize(s.Children)
 }
 
-// Dump - box-specific dump
-func (s *StblBox) Dump() {
-	if s.Stsc != nil {
-		s.Stsc.Dump()
-	}
-	if s.Stts != nil {
-		s.Stts.Dump()
-	}
-	if s.Stsz != nil {
-		s.Stsz.Dump()
-	}
-	if s.Stss != nil {
-		s.Stss.Dump()
-	}
-	if s.Stco != nil {
-		s.Stco.Dump()
-	}
-}
-
 // GetChildren - list of child boxes
 func (s *StblBox) GetChildren() []Box {
 	return s.Children
@@ -97,4 +78,8 @@ func (s *StblBox) GetChildren() []Box {
 // Encode - write stbl container to w
 func (s *StblBox) Encode(w io.Writer) error {
 	return EncodeContainer(s, w)
+}
+
+func (s *StblBox) Dump(w io.Writer, indent, indentStep string) error {
+	return DumpContainer(s, w, indent, indentStep)
 }

--- a/mp4/stco.go
+++ b/mp4/stco.go
@@ -51,14 +51,6 @@ func (b *StcoBox) Size() uint64 {
 	return uint64(boxHeaderSize + 8 + len(b.ChunkOffset)*4)
 }
 
-// Dump - box-specific dump
-func (b *StcoBox) Dump() {
-	fmt.Println("Chunk byte offsets:")
-	for i, o := range b.ChunkOffset {
-		fmt.Printf(" #%d : starts at %d\n", i, o)
-	}
-}
-
 // Encode - box-specific encode
 func (b *StcoBox) Encode(w io.Writer) error {
 	err := EncodeHeader(b, w)
@@ -74,5 +66,10 @@ func (b *StcoBox) Encode(w io.Writer) error {
 		sw.WriteUint32(b.ChunkOffset[i])
 	}
 	_, err = w.Write(buf)
+	return err
+}
+
+func (s *StcoBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, s.Type(), s.Size())
 	return err
 }

--- a/mp4/stsc.go
+++ b/mp4/stsc.go
@@ -60,14 +60,6 @@ func (b *StscBox) Size() uint64 {
 	return uint64(boxHeaderSize + 8 + len(b.FirstChunk)*12)
 }
 
-// Dump - box-specific dump
-func (b *StscBox) Dump() {
-	fmt.Println("Sample to Chunk:")
-	for i := range b.SamplesPerChunk {
-		fmt.Printf(" #%d : %d samples per chunk starting @chunk #%d \n", i, b.SamplesPerChunk[i], b.FirstChunk[i])
-	}
-}
-
 // Encode - box-specific encode
 func (b *StscBox) Encode(w io.Writer) error {
 	err := EncodeHeader(b, w)
@@ -85,6 +77,11 @@ func (b *StscBox) Encode(w io.Writer) error {
 		sw.WriteUint32(b.SampleDescriptionID[i])
 	}
 	_, err = w.Write(buf)
+	return err
+}
+
+func (s *StscBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, s.Type(), s.Size())
 	return err
 }
 

--- a/mp4/stsd.go
+++ b/mp4/stsd.go
@@ -3,6 +3,7 @@ package mp4
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 )
 
@@ -132,4 +133,9 @@ func (s *StsdBox) Encode(w io.Writer) error {
 		}
 	}
 	return nil
+}
+
+func (s *StsdBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, s.Type(), s.Size())
+	return err
 }

--- a/mp4/stss.go
+++ b/mp4/stss.go
@@ -61,14 +61,6 @@ func (b *StssBox) IsSyncSample(sampleNr uint32) (isSync bool) {
 	return
 }
 
-// Dump - box-specific dump
-func (b *StssBox) Dump() {
-	fmt.Println("Key frames:")
-	for i, n := range b.SampleNumber {
-		fmt.Printf(" #%d : sample #%d\n", i, n)
-	}
-}
-
 // Encode - box-specific encode
 func (b *StssBox) Encode(w io.Writer) error {
 	err := EncodeHeader(b, w)
@@ -84,5 +76,10 @@ func (b *StssBox) Encode(w io.Writer) error {
 		sw.WriteUint32(b.SampleNumber[i])
 	}
 	_, err = w.Write(buf)
+	return err
+}
+
+func (s *StssBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, s.Type(), s.Size())
 	return err
 }

--- a/mp4/stsz.go
+++ b/mp4/stsz.go
@@ -57,15 +57,6 @@ func (b *StszBox) Size() uint64 {
 	return uint64(boxHeaderSize + 12 + len(b.SampleSize)*4)
 }
 
-// Dump - print box info
-func (b *StszBox) Dump() {
-	if len(b.SampleSize) == 0 {
-		fmt.Printf("Samples : %d total samples\n", b.SampleNumber)
-	} else {
-		fmt.Printf("Samples : %d total samples\n", len(b.SampleSize))
-	}
-}
-
 // GetSampleSize returns the size (in bytes) of a sample
 func (b *StszBox) GetSampleSize(i int) uint32 {
 	if i > len(b.SampleSize) {
@@ -94,5 +85,10 @@ func (b *StszBox) Encode(w io.Writer) error {
 		}
 	}
 	_, err = w.Write(buf)
+	return err
+}
+
+func (s *StszBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, s.Type(), s.Size())
 	return err
 }

--- a/mp4/stts.go
+++ b/mp4/stts.go
@@ -93,14 +93,6 @@ func (b *SttsBox) GetDecodeTime(sampleNr uint32) (decTime uint64, dur uint32) {
 	return
 }
 
-// Dump - write box-specific details
-func (b *SttsBox) Dump() {
-	fmt.Println("Time to sample:")
-	for i := range b.SampleCount {
-		fmt.Printf(" #%d : %d samples with duration %d units\n", i, b.SampleCount[i], b.SampleTimeDelta[i])
-	}
-}
-
 // Encode - write box to w
 func (b *SttsBox) Encode(w io.Writer) error {
 	err := EncodeHeader(b, w)
@@ -117,5 +109,9 @@ func (b *SttsBox) Encode(w io.Writer) error {
 		sw.WriteUint32(b.SampleTimeDelta[i])
 	}
 	_, err = w.Write(buf)
+	return err
+}
+func (s *SttsBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, s.Type(), s.Size())
 	return err
 }

--- a/mp4/styp.go
+++ b/mp4/styp.go
@@ -42,11 +42,6 @@ func (b *StypBox) Size() uint64 {
 	return uint64(boxHeaderSize + 8 + 4*len(b.CompatibleBrands))
 }
 
-// Dump - print box info
-func (b *StypBox) Dump() {
-	fmt.Printf("Segment Type: %s\n", b.MajorBrand)
-}
-
 // Encode - write box to w
 func (b *StypBox) Encode(w io.Writer) error {
 	err := EncodeHeader(b, w)
@@ -60,5 +55,11 @@ func (b *StypBox) Encode(w io.Writer) error {
 		strtobuf(buf[8+i*4:], c, 4)
 	}
 	_, err = w.Write(buf)
+	return err
+}
+
+func (b *StypBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n%s - Major Brand: %s\n",
+		indent, b.Type(), b.Size(), indent, b.MajorBrand)
 	return err
 }

--- a/mp4/tfdt.go
+++ b/mp4/tfdt.go
@@ -1,6 +1,7 @@
 package mp4
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 )
@@ -87,5 +88,10 @@ func (t *TfdtBox) Encode(w io.Writer) error {
 		sw.WriteUint64(t.BaseMediaDecodeTime)
 	}
 	_, err = w.Write(buf)
+	return err
+}
+
+func (t *TfdtBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, t.Type(), t.Size())
 	return err
 }

--- a/mp4/tfhd.go
+++ b/mp4/tfhd.go
@@ -142,11 +142,6 @@ func (t *TfhdBox) Size() uint64 {
 	return uint64(sz)
 }
 
-// Dump - print box specific data
-func (t *TfhdBox) Dump() {
-	fmt.Printf("Track Fragment Header:\n Track ID: %d\n", t.TrackID)
-}
-
 // Encode - write box to w
 func (t *TfhdBox) Encode(w io.Writer) error {
 	err := EncodeHeader(t, w)
@@ -175,5 +170,10 @@ func (t *TfhdBox) Encode(w io.Writer) error {
 	}
 
 	_, err = w.Write(buf)
+	return err
+}
+
+func (t *TfhdBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, t.Type(), t.Size())
 	return err
 }

--- a/mp4/tkhd.go
+++ b/mp4/tkhd.go
@@ -127,8 +127,7 @@ func (b *TkhdBox) Encode(w io.Writer) error {
 	return err
 }
 
-// Dump - print box info
-func (b *TkhdBox) Dump() {
-	fmt.Println("Track Header:")
-	fmt.Printf(" Duration: %d units\n WxH: %sx%s\n", b.Duration, b.Width, b.Height)
+func (b *TkhdBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, b.Type(), b.Size())
+	return err
 }

--- a/mp4/traf.go
+++ b/mp4/traf.go
@@ -70,6 +70,10 @@ func (t *TrafBox) Encode(w io.Writer) error {
 	return EncodeContainer(t, w)
 }
 
+func (t *TrafBox) Dump(w io.Writer, indent, indentStep string) error {
+	return DumpContainer(t, w, indent, indentStep)
+}
+
 // OptimizeTfhdTrun - optimize trun by default values in tfhd box
 func (t *TrafBox) OptimizeTfhdTrun() error {
 	tfhd := t.Tfhd

--- a/mp4/trak.go
+++ b/mp4/trak.go
@@ -58,15 +58,6 @@ func (t *TrakBox) Size() uint64 {
 	return containerSize(t.Children)
 }
 
-// Dump - print box info
-func (t *TrakBox) Dump() {
-	t.Tkhd.Dump()
-	if t.Edts != nil {
-		t.Edts.Dump()
-	}
-	t.Mdia.Dump()
-}
-
 // GetChildren - list of child boxes
 func (t *TrakBox) GetChildren() []Box {
 	return t.Children
@@ -75,4 +66,8 @@ func (t *TrakBox) GetChildren() []Box {
 // Encode - write trak container to w
 func (t *TrakBox) Encode(w io.Writer) error {
 	return EncodeContainer(t, w)
+}
+
+func (t *TrakBox) Dump(w io.Writer, indent, indentStep string) error {
+	return DumpContainer(t, w, indent, indentStep)
 }

--- a/mp4/trex.go
+++ b/mp4/trex.go
@@ -1,6 +1,7 @@
 package mp4
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 )
@@ -73,5 +74,10 @@ func (t *TrexBox) Encode(w io.Writer) error {
 	sw.WriteUint32(t.DefaultSampleSize)
 	sw.WriteUint32(t.DefaultSampleFlags)
 	_, err = w.Write(buf)
+	return err
+}
+
+func (t *TrexBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, t.Type(), t.Size())
 	return err
 }

--- a/mp4/trun.go
+++ b/mp4/trun.go
@@ -1,6 +1,7 @@
 package mp4
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 )
@@ -226,6 +227,11 @@ func (t *TrunBox) Encode(w io.Writer) error {
 
 	}
 	_, err = w.Write(buf)
+	return err
+}
+
+func (t *TrunBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, t.Type(), t.Size())
 	return err
 }
 

--- a/mp4/unknown.go
+++ b/mp4/unknown.go
@@ -1,6 +1,7 @@
 package mp4
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 )
@@ -38,5 +39,10 @@ func (b *UnknownBox) Encode(w io.Writer) error {
 		return err
 	}
 	_, err = w.Write(b.notDecoded)
+	return err
+}
+
+func (b *UnknownBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, b.Type(), b.Size())
 	return err
 }

--- a/mp4/url.go
+++ b/mp4/url.go
@@ -1,6 +1,7 @@
 package mp4
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 )
@@ -76,5 +77,11 @@ func (u *URLBox) Encode(w io.Writer) error {
 		sw.WriteString(u.Location, true)
 	}
 	_, err = w.Write(buf)
+	return err
+}
+func (u *URLBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n%s - location: %s",
+		indent, u.Type(), u.Size(),
+		indent, u.Location)
 	return err
 }

--- a/mp4/uuid.go
+++ b/mp4/uuid.go
@@ -190,3 +190,8 @@ func (t *TfrfData) encode(w io.Writer) error {
 	_, err := w.Write(buf)
 	return err
 }
+
+func (u *UUIDBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, u.Type(), u.Size())
+	return err
+}

--- a/mp4/visualsampleentry.go
+++ b/mp4/visualsampleentry.go
@@ -2,6 +2,7 @@ package mp4
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 )
@@ -172,5 +173,10 @@ func (a *VisualSampleEntryBox) Encode(w io.Writer) error {
 			return err
 		}
 	}
+	return err
+}
+
+func (a *VisualSampleEntryBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, a.Type(), a.Size())
 	return err
 }

--- a/mp4/vmhd.go
+++ b/mp4/vmhd.go
@@ -1,6 +1,7 @@
 package mp4
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 )
@@ -64,5 +65,10 @@ func (b *VmhdBox) Encode(w io.Writer) error {
 		sw.WriteUint16(b.OpColor[i])
 	}
 	_, err = w.Write(buf)
+	return err
+}
+
+func (b *VmhdBox) Dump(w io.Writer, indent, indentStep string) error {
+	_, err := fmt.Fprintf(w, "%s%s size=%d\n", indent, b.Type(), b.Size())
 	return err
 }


### PR DESCRIPTION
One can now call Dump on all boxes to print a tree of the whole box structure.
The information about each box is minimal, but it is a start and more details will be added
where it is most valuable.

The new example `tree` is a minimal command line tool that prints the box structure of an mp4 file. 