### PR TITLE
Move avc code to own package

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ it can be calculated. It is set to `MoofBox.Size()+8`.
 
 Some simple command line tools are available in `cmd`.
 
+1. `mp4ff-pslister` extracts and displays pps and sps for AVC in an mp4 file
+
 ## Example code
 
 Example code is available in the `examples` directory.

--- a/avc/avc.go
+++ b/avc/avc.go
@@ -26,10 +26,10 @@ const (
 	ExtendedSAR = 255
 )
 
-// AvcNalType -
-type AvcNalType uint16
+// NalType - AVC nal type
+type NalType uint16
 
-func (a AvcNalType) String() string {
+func (a NalType) String() string {
 	switch a {
 	case NALU_SEI:
 		return "SEI"
@@ -45,14 +45,14 @@ func (a AvcNalType) String() string {
 }
 
 // Get NalType from NAL Header byte
-func GetNalType(nalHeader byte) AvcNalType {
-	return AvcNalType(nalHeader & 0x1f)
+func GetNalType(nalHeader byte) NalType {
+	return NalType(nalHeader & 0x1f)
 }
 
-// FindAvcNalTypes - find list of nal types
-func FindAvcNalTypes(b []byte) []AvcNalType {
+// FindNalTypes - find list of nal types
+func FindNalTypes(b []byte) []NalType {
 	var pos uint32 = 0
-	nalList := make([]AvcNalType, 0)
+	nalList := make([]NalType, 0)
 	length := len(b)
 	if length < 4 {
 		return nalList
@@ -60,16 +60,16 @@ func FindAvcNalTypes(b []byte) []AvcNalType {
 	for pos < uint32(length-4) {
 		nalLength := binary.BigEndian.Uint32(b[pos : pos+4])
 		pos += 4
-		nalType := AvcNalType(b[pos] & 0x1f)
+		nalType := NalType(b[pos] & 0x1f)
 		nalList = append(nalList, nalType)
 		pos += nalLength
 	}
 	return nalList
 }
 
-// HasAvcParameterSets - Check if H.264 SPS and PPS are present
-func HasAvcParameterSets(b []byte) bool {
-	nalTypeList := FindAvcNalTypes(b)
+// HasParameterSets - Check if H.264 SPS and PPS are present
+func HasParameterSets(b []byte) bool {
+	nalTypeList := FindNalTypes(b)
 	hasSPS := false
 	hasPPS := false
 	for _, nalType := range nalTypeList {
@@ -86,8 +86,8 @@ func HasAvcParameterSets(b []byte) bool {
 	return false
 }
 
-// AvcSPS - AVC SPS parameters
-type AvcSPS struct {
+// SPS - AVC SPS parameters
+type SPS struct {
 	Profile                         uint
 	ProfileCompatibility            uint
 	Level                           uint
@@ -187,9 +187,9 @@ type CpbEntry struct {
 }
 
 // ParseSPSNALUnit - Parse AVC SPS NAL unit starting with NAL header
-func ParseSPSNALUnit(data []byte, parseVUIBeyondAspectRatio bool) (*AvcSPS, error) {
+func ParseSPSNALUnit(data []byte, parseVUIBeyondAspectRatio bool) (*SPS, error) {
 
-	sps := &AvcSPS{}
+	sps := &SPS{}
 
 	rd := bytes.NewReader(data)
 	reader := bits.NewEBSPReader(rd)
@@ -436,7 +436,7 @@ func parseHrdParameters(r *bits.EBSPReader) *HrdParameters {
 }
 
 // ConstraintFlags - return the four ConstraintFlag bits
-func (a *AvcSPS) ConstraintFlags() byte {
+func (a *SPS) ConstraintFlags() byte {
 	return byte(a.ProfileCompatibility >> 4)
 }
 

--- a/avc/avc.go
+++ b/avc/avc.go
@@ -11,23 +11,23 @@ import (
 
 var ErrNotSPS = errors.New("Not an SPS NAL unit")
 
+// NalType - AVC nal type
+type NalType uint16
+
 const (
 	// NALU_SEI - Supplementary Enhancement Information NAL Unit
-	NALU_SEI = 6
+	NALU_SEI = NalType(6)
 	// NALU_SSP - SequenceParameterSet NAL Unit
-	NALU_SPS = 7
+	NALU_SPS = NalType(7)
 	// NALU_PPS - PictureParameterSet NAL Unit
-	NALU_PPS = 8
+	NALU_PPS = NalType(8)
 	// NALU_AUD - AccessUnitDelimiter NAL Unit
-	NALU_AUD = 9
+	NALU_AUD = NalType(9)
 	// NALU_FILL - Filler NAL Unit
-	NALU_FILL = 12
+	NALU_FILL = NalType(12)
 	// ExtendedSAR - Extended Sample Aspect Ratio Code
 	ExtendedSAR = 255
 )
-
-// NalType - AVC nal type
-type NalType uint16
 
 func (a NalType) String() string {
 	switch a {
@@ -199,7 +199,7 @@ func ParseSPSNALUnit(data []byte, parseVUIBeyondAspectRatio bool) (*SPS, error) 
 	if err != nil {
 		return nil, err
 	}
-	nalType := nalHdr & 0x1f
+	nalType := GetNalType(byte(nalHdr))
 	if nalType != NALU_SPS {
 		return nil, ErrNotSPS
 	}

--- a/avc/avc.go
+++ b/avc/avc.go
@@ -1,4 +1,4 @@
-package mp4
+package avc
 
 import (
 	"bytes"

--- a/avc/avc_test.go
+++ b/avc/avc_test.go
@@ -13,7 +13,7 @@ const sps2nalu = "6764000dacd941419f9e10000003001000000303c0f1429960"
 func TestSPSParser1(t *testing.T) {
 	byteData, _ := hex.DecodeString(sps1nalu)
 
-	wanted := AvcSPS{
+	wanted := SPS{
 		Profile:                         100,
 		ProfileCompatibility:            0,
 		Level:                           32,
@@ -73,7 +73,7 @@ func TestSPSParser1(t *testing.T) {
 func TestSPSParser2(t *testing.T) {
 	byteData, _ := hex.DecodeString(sps2nalu)
 
-	wanted := AvcSPS{
+	wanted := SPS{
 		Profile:                         100,
 		ProfileCompatibility:            0,
 		Level:                           13,

--- a/avc/avc_test.go
+++ b/avc/avc_test.go
@@ -1,4 +1,4 @@
-package mp4
+package avc
 
 import (
 	"encoding/hex"
@@ -7,11 +7,7 @@ import (
 	"github.com/go-test/deep"
 )
 
-// From ~tobbe/content/encmompass/dazn_ad/video_4400kbps/init.cmfv (dropped 67)
 const sps1nalu = "67640020accac05005bb0169e0000003002000000c9c4c000432380008647c12401cb1c31380"
-
-// From test in repackaging-poc
-
 const sps2nalu = "6764000dacd941419f9e10000003001000000303c0f1429960"
 
 func TestSPSParser1(t *testing.T) {

--- a/avc/avcdecoderconfig_test.go
+++ b/avc/avcdecoderconfig_test.go
@@ -1,4 +1,4 @@
-package mp4
+package avc
 
 import (
 	"bytes"

--- a/avc/avcdecoderconfigurationrecord.go
+++ b/avc/avcdecoderconfigurationrecord.go
@@ -1,4 +1,4 @@
-package mp4
+package avc
 
 import (
 	"encoding/binary"

--- a/avc/slice.go
+++ b/avc/slice.go
@@ -1,0 +1,77 @@
+package avc
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/edgeware/mp4ff/bits"
+)
+
+var ErrNoSliceHeader = errors.New("No slice header")
+var ErrInvalidSliceType = errors.New("Invalid slice type")
+var ErrTooFewBytesToParse = errors.New("Too few bytes to parse symbol")
+
+type SliceType uint
+
+func (s SliceType) String() string {
+	switch s {
+	case SLICE_I:
+		return "I"
+	case SLICE_P:
+		return "P"
+	case SLICE_B:
+		return "B"
+	default:
+		return ""
+	}
+}
+
+const (
+	SLICE_P  = SliceType(0)
+	SLICE_B  = SliceType(1)
+	SLICE_I  = SliceType(2)
+	SLICE_SP = SliceType(3)
+	SLICE_SI = SliceType(4)
+)
+
+// GetSliceTypeFromNAL - parse slice header to get slice type in interval 0 to 4
+func GetSliceTypeFromNAL(data []byte) (sliceType SliceType, err error) {
+
+	if len(data) <= 1 {
+		err = ErrTooFewBytesToParse
+		return
+	}
+
+	nalType := GetNalType(data[0])
+	switch nalType {
+	case 1, 2, 5, 19:
+		// slice_layer_without_partitioning_rbsp
+		// slice_data_partition_a_layer_rbsp
+
+	default:
+		err = ErrNoSliceHeader
+		return
+	}
+	r := bits.NewEBSPReader(bytes.NewReader((data[1:])))
+
+	// first_mb_in_slice
+	if _, err = r.ReadExpGolomb(); err != nil {
+		return
+	}
+
+	// slice_type
+	var st uint
+	if st, err = r.ReadExpGolomb(); err != nil {
+		return
+	}
+	sliceType = SliceType(st)
+	if sliceType > 9 {
+		err = ErrInvalidSliceType
+		return
+	}
+
+	if sliceType >= 5 {
+		sliceType -= 5 // The same type is repeated twice to tell if all slices in picture are the same
+	}
+	return
+}

--- a/avc/slice_test.go
+++ b/avc/slice_test.go
@@ -1,0 +1,20 @@
+package avc
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+const videoNaluStart = "25888040ffde08e47a7bff05ab"
+
+func TestSliceTypeParser(t *testing.T) {
+	byteData, _ := hex.DecodeString(videoNaluStart)
+	want := SLICE_I
+	got, err := GetSliceTypeFromNAL(byteData)
+	if err != nil {
+		t.Error(err)
+	}
+	if got != want {
+		t.Errorf("got %s want %s", got, want)
+	}
+}

--- a/cmd/mp4ff-pslister/main.go
+++ b/cmd/mp4ff-pslister/main.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/edgeware/mp4ff/avc"
 	"github.com/edgeware/mp4ff/mp4"
 	log "github.com/sirupsen/logrus"
 )
@@ -63,7 +64,7 @@ func main() {
 			for i, sps := range avcC.SPSnalus {
 				hexStr := hex.EncodeToString(sps)
 				length := len(hexStr) / 2
-				spsInfo, err := mp4.ParseSPSNALUnit(sps, *fullVUI)
+				spsInfo, err := avc.ParseSPSNALUnit(sps, *fullVUI)
 				if err != nil {
 					fmt.Println("Could not parse SPS")
 					return

--- a/mp4/avcc.go
+++ b/mp4/avcc.go
@@ -3,24 +3,26 @@ package mp4
 import (
 	"fmt"
 	"io"
+
+	"github.com/edgeware/mp4ff/avc"
 )
 
 // AvcCBox - AVCConfigurationBox (ISO/IEC 14496-15 5.4.2.1.2 and 5.3.3.1.2)
 // Contains one AVCDecoderConfigurationRecord
 type AvcCBox struct {
-	AVCDecConfRec
+	avc.AVCDecConfRec
 }
 
 // CreateAvcC - Create an avcC box based on SPS and PPS
 func CreateAvcC(spsNALU []byte, ppsNALUs [][]byte) *AvcCBox {
-	avcDecConfRec := CreateAVCDecConfRec(spsNALU, ppsNALUs)
+	avcDecConfRec := avc.CreateAVCDecConfRec(spsNALU, ppsNALUs)
 
 	return &AvcCBox{avcDecConfRec}
 }
 
 // DecodeAvcC - box-specific decode
 func DecodeAvcC(hdr *boxHeader, startPos uint64, r io.Reader) (Box, error) {
-	avcDecConfRec, err := DecodeAVCDecConfRec(r)
+	avcDecConfRec, err := avc.DecodeAVCDecConfRec(r)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/initsegment.go
+++ b/mp4/initsegment.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+
+	"github.com/edgeware/mp4ff/avc"
 )
 
 // InitSegment - MP4/CMAF init segment
@@ -144,7 +146,7 @@ func CreateEmptyMP4Init(timeScale uint32, mediaType, language string) *InitSegme
 // SetAVCDescriptor - Modify a TrakBox by adding AVC SampleDescriptor from one SPS and multiple PPS
 // Get width and height from SPS and fill into tkhd box.
 func (t *TrakBox) SetAVCDescriptor(sampleDescriptorType string, spsNALU []byte, ppsNALUs [][]byte) {
-	avcSPS, err := ParseSPSNALUnit(spsNALU, false)
+	avcSPS, err := avc.ParseSPSNALUnit(spsNALU, false)
 	if err != nil {
 		panic("Cannot handle SPS parsing errors")
 	}

--- a/mp4/initsegment_test.go
+++ b/mp4/initsegment_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 )
 
+const sps1nalu = "67640020accac05005bb0169e0000003002000000c9c4c000432380008647c12401cb1c31380"
+
 func parseInitFile(fileName string) (*File, error) {
 	fd, err := os.Open(fileName)
 	if err != nil {


### PR DESCRIPTION
AVC parsing and types in separate package to prepare for HEVC addition at later stage.
Allows for simpler names without AVC.
Also added Slice type parsing.