### PR TITLE
Fix of segmenter example to read samples from mdat

### DIFF
--- a/examples/segmenter/main.go
+++ b/examples/segmenter/main.go
@@ -76,7 +76,7 @@ func main() {
 		newSegment := false
 		for _, tr := range segmenter.tracks {
 			mediaType := tr.trackType
-			samples := segmenter.GetSamplesUntilTime(tr, ifd, tr.nextSampleNr, segDurMs*segNr)
+			samples := segmenter.GetSamplesUntilTime(parsedMp4, tr, tr.nextSampleNr, segDurMs*segNr)
 			if len(samples) == 0 {
 				continue
 			}


### PR DESCRIPTION
mdat has all data in a slice, so the samples should be read from mdat.
In the future, we may have a lazy mdat that reads on request.