### PR TITLE
feat: support alst, rap , roll SampleGroupEntries

### DIFF
--- a/mp4/samplegroupentries.go
+++ b/mp4/samplegroupentries.go
@@ -153,7 +153,11 @@ func (s *UnknownSampleGroupEntry) Info(w io.Writer, specificBoxLevels, indent, i
 	return bd.err
 }
 
-// RollSampleGroupEntry - Grouping Type "roll"
+// RollSampleGroupEntry - Gradual Decoding Refresh "roll"
+//
+// ISO/IEC 14496-12 Ed. 6 2020 Section 10.1
+//
+// VisualRollRecoveryEntry / AudioRollRecoveryEntry / AudioPreRollEntry
 type RollSampleGroupEntry struct {
 	RollDistance int16
 }
@@ -183,7 +187,9 @@ func (s *RollSampleGroupEntry) Info(w io.Writer, specificBoxLevels, indent, inde
 	return bd.err
 }
 
-// RapSampleGroupEntry - Grouping Type "rap "
+// RapSampleGroupEntry - Random Access Point "rap "
+//
+// ISO/IEC 14496-12 Ed. 6 2020 Section 10.4 - VisualRandomAccessEntry
 type RapSampleGroupEntry struct {
 	NumLeadingSamplesKnown uint8
 	NumLeadingSamples      uint8
@@ -220,7 +226,9 @@ func (s *RapSampleGroupEntry) Info(w io.Writer, specificBoxLevels, indent, inden
 	return bd.err
 }
 
-// AlstSampleGroupEntry - Alternative Startup Entry - Grouping Type "alst"
+// AlstSampleGroupEntry - Alternative Startup Entry "alst"
+//
+// ISO/IEC 14496-12 Ed. 6 2020 Section 10.3 - AlternativeStartupEntry
 type AlstSampleGroupEntry struct {
 	RollCount         uint16
 	FirstOutputSample uint16
@@ -287,11 +295,11 @@ func (s *AlstSampleGroupEntry) Info(w io.Writer, specificBoxLevels, indent, inde
 	level := getInfoLevel(s, specificBoxLevels)
 	if level > 0 {
 		for i, offset := range s.SampleOffset {
-			bd.write(" * sampleOffset[%d]: %d", i, offset)
+			bd.write(" * sampleOffset[%d]: %d", i+1, offset)
 		}
 		for i := range s.NumOutputSamples {
-			bd.write(" * numOutputSamples[%d]: %d", i, s.NumOutputSamples[i])
-			bd.write(" * numTotalSamples[%d]: %d", i, s.NumTotalSamples[i])
+			bd.write(" * numOutputSamples[%d]: %d", i+1, s.NumOutputSamples[i])
+			bd.write(" * numTotalSamples[%d]: %d", i+1, s.NumTotalSamples[i])
 		}
 	}
 	return bd.err

--- a/mp4/samplegroupentries.go
+++ b/mp4/samplegroupentries.go
@@ -26,6 +26,9 @@ var sgeDecoders map[string]SampleGroupEntryDecoder
 func init() {
 	sgeDecoders = map[string]SampleGroupEntryDecoder{
 		"seig": DecodeSeigSampleGroupEntry,
+		"roll": DecodeRollSampleGroupEntry,
+		"rap ": DecodeRapSampleGroupEntry,
+		"alst": DecodeAlstSampleGroupEntry,
 	}
 }
 
@@ -146,6 +149,150 @@ func (s *UnknownSampleGroupEntry) Info(w io.Writer, specificBoxLevels, indent, i
 	level := getInfoLevel(s, specificBoxLevels)
 	if level > 0 {
 		bd.write(" * data: %s", hex.EncodeToString(s.Data))
+	}
+	return bd.err
+}
+
+// RollSampleGroupEntry - Grouping Type "roll"
+type RollSampleGroupEntry struct {
+	RollDistance int16
+}
+
+func DecodeRollSampleGroupEntry(name string, length uint32, sr *SliceReader) (SampleGroupEntry, error) {
+	entry := &RollSampleGroupEntry{}
+	entry.RollDistance = sr.ReadInt16()
+	return entry, nil
+}
+
+func (s *RollSampleGroupEntry) Type() string {
+	return "roll"
+}
+
+func (s *RollSampleGroupEntry) Size() uint64 {
+	return 2
+}
+
+func (s *RollSampleGroupEntry) Encode(sw *SliceWriter) {
+	sw.WriteInt16(s.RollDistance)
+}
+
+// Info - write box info to w
+func (s *RollSampleGroupEntry) Info(w io.Writer, specificBoxLevels, indent, indentStep string) (err error) {
+	bd := newInfoDumper(w, indent, s, -2)
+	bd.write(" * rollDistance: %d", s.RollDistance)
+	return bd.err
+}
+
+// RapSampleGroupEntry - Grouping Type "rap "
+type RapSampleGroupEntry struct {
+	NumLeadingSamplesKnown uint8
+	NumLeadingSamples      uint8
+}
+
+func DecodeRapSampleGroupEntry(name string, length uint32, sr *SliceReader) (SampleGroupEntry, error) {
+	entry := &RapSampleGroupEntry{}
+	byt := sr.ReadUint8()
+	entry.NumLeadingSamplesKnown = byt >> 7
+	entry.NumLeadingSamples = byt & 0x7F
+	return entry, nil
+}
+
+func (s *RapSampleGroupEntry) Type() string {
+	return "rap "
+}
+
+func (s *RapSampleGroupEntry) Size() uint64 {
+	return 1
+}
+
+func (s *RapSampleGroupEntry) Encode(sw *SliceWriter) {
+	var byt uint8
+	byt |= (s.NumLeadingSamplesKnown << 7)
+	byt |= (s.NumLeadingSamples)
+	sw.WriteUint8(byt)
+}
+
+// Info - write box info to w
+func (s *RapSampleGroupEntry) Info(w io.Writer, specificBoxLevels, indent, indentStep string) (err error) {
+	bd := newInfoDumper(w, indent, s, -2)
+	bd.write(" * numLeadingSamplesKnown: %d", s.NumLeadingSamplesKnown)
+	bd.write(" * numLeadingSamples: %d", s.NumLeadingSamples)
+	return bd.err
+}
+
+// AlstSampleGroupEntry - Alternative Startup Entry - Grouping Type "alst"
+type AlstSampleGroupEntry struct {
+	RollCount         uint16
+	FirstOutputSample uint16
+	SampleOffset      []uint32
+	NumOutputSamples  []uint16
+	NumTotalSamples   []uint16
+}
+
+func (s *AlstSampleGroupEntry) Type() string {
+	return "alst "
+}
+
+func (s *AlstSampleGroupEntry) Size() uint64 {
+	// RollCount: 2
+	// FirstOutputSample: 2
+	// SampleOffset: 4 * count
+	// NumOutputSamples: 2 * count
+	// NumTotalSamples: 2 * count
+	return uint64(4 + 4*len(s.SampleOffset) + 2*len(s.NumOutputSamples) + 2*len(s.NumTotalSamples))
+}
+
+func DecodeAlstSampleGroupEntry(name string, length uint32, sr *SliceReader) (SampleGroupEntry, error) {
+	entry := &AlstSampleGroupEntry{}
+	entry.RollCount = sr.ReadUint16()
+	entry.FirstOutputSample = sr.ReadUint16()
+	entry.SampleOffset = make([]uint32, int(entry.RollCount))
+	for i := 0; i < int(entry.RollCount); i++ {
+		entry.SampleOffset[i] = sr.ReadUint32()
+	}
+
+	remaining := int(length-uint32(entry.Size())) / 4
+	if remaining <= 0 {
+		return entry, nil
+	}
+
+	// Optional
+	entry.NumOutputSamples = make([]uint16, remaining)
+	entry.NumTotalSamples = make([]uint16, remaining)
+	for i := 0; i < remaining; i++ {
+		entry.NumOutputSamples[i] = sr.ReadUint16()
+		entry.NumTotalSamples[i] = sr.ReadUint16()
+	}
+
+	return entry, nil
+}
+
+func (s *AlstSampleGroupEntry) Encode(sw *SliceWriter) {
+	sw.WriteUint16(s.RollCount)
+	sw.WriteUint16(s.FirstOutputSample)
+	for _, offset := range s.SampleOffset {
+		sw.WriteUint32(offset)
+	}
+	for i := range s.NumOutputSamples {
+		sw.WriteUint16(s.NumOutputSamples[i])
+		sw.WriteUint16(s.NumTotalSamples[i])
+	}
+}
+
+// Info - write box info to w
+func (s *AlstSampleGroupEntry) Info(w io.Writer, specificBoxLevels, indent, indentStep string) (err error) {
+	bd := newInfoDumper(w, indent, s, -2)
+	bd.write(" * rollDistance: %d", s.RollCount)
+	bd.write(" * firstOutputSample: %d", s.FirstOutputSample)
+	level := getInfoLevel(s, specificBoxLevels)
+	if level > 0 {
+		for i, offset := range s.SampleOffset {
+			bd.write(" * sampleOffset[%d]: %d", i, offset)
+		}
+		for i := range s.NumOutputSamples {
+			bd.write(" * numOutputSamples[%d]: %d", i, s.NumOutputSamples[i])
+			bd.write(" * numTotalSamples[%d]: %d", i, s.NumTotalSamples[i])
+		}
 	}
 	return bd.err
 }

--- a/mp4/sgpd_test.go
+++ b/mp4/sgpd_test.go
@@ -1,0 +1,26 @@
+package mp4
+
+import (
+	"testing"
+)
+
+func TestSgpd(t *testing.T) {
+
+	rollEntry := &RollSampleGroupEntry{RollDistance: -1}
+	rapEntry := &RapSampleGroupEntry{NumLeadingSamplesKnown: 1, NumLeadingSamples: 12}
+	alstEntry := &AlstSampleGroupEntry{RollCount: 2, FirstOutputSample: 1, SampleOffset: []uint32{7000, 1234}}
+	unknownEntry := &UnknownSampleGroupEntry{Name: "tele", Data: []byte{0x80}}
+	unknownEntry2 := &UnknownSampleGroupEntry{Name: "tele", Data: []byte{0x00}}
+
+	sgpds := []*SgpdBox{
+		{Version: 1, GroupingType: "roll", DefaultLength: 2, SampleGroupEntries: []SampleGroupEntry{rollEntry}},
+		{Version: 1, GroupingType: "rap ", DefaultLength: 1, SampleGroupEntries: []SampleGroupEntry{rapEntry}},
+		{Version: 1, GroupingType: "alst", DefaultLength: 12, SampleGroupEntries: []SampleGroupEntry{alstEntry}},
+		{Version: 1, GroupingType: "tele", DefaultLength: 1, SampleGroupEntries: []SampleGroupEntry{unknownEntry, unknownEntry2}},
+	}
+
+	for _, sgpd := range sgpds {
+		boxDiffAfterEncodeAndDecode(t, sgpd)
+	}
+
+}


### PR DESCRIPTION
Conform to the new SampleGroupEntry interface.

"roll" is the only one that I experience in the wild. Other SampleGroups checked against clips from 
http://download.tsi.telecom-paristech.fr/gpac/MPEG/ISOBMFF-Conformance/