### PR TITLE
Fix for trun optimize

### DIFF
--- a/mp4/file.go
+++ b/mp4/file.go
@@ -218,13 +218,22 @@ func (f *File) Encode(w io.Writer) error {
 				return err
 			}
 		}
+		if !f.EncodeVerbatim {
+			for _, seg := range f.Segments {
+				err := seg.Encode(w)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		// Fragmented and Verbatim. Don't optimize trun
 		for _, seg := range f.Segments {
-			err := seg.Encode(w)
+			err := seg.EncodeVerbatim(w)
 			if err != nil {
 				return err
 			}
 		}
-		return nil
 	}
 	// Progressive file
 	for _, b := range f.Children {

--- a/mp4/fragment.go
+++ b/mp4/fragment.go
@@ -253,3 +253,21 @@ func (f *Fragment) SetTrunDataOffsets() {
 		dataOffset += trun.SizeOfData()
 	}
 }
+
+// EncodeVerbatim - write fragment without trun optimiztion via writer
+func (f *Fragment) EncodeVerbatim(w io.Writer) error {
+	if f.Moof == nil {
+		return fmt.Errorf("moof not set in fragment")
+	}
+	if f.Mdat == nil {
+		return fmt.Errorf("mdat not set in fragment")
+	}
+	f.SetTrunDataOffsets()
+	for _, b := range f.Children {
+		err := b.Encode(w)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/mp4/fragment.go
+++ b/mp4/fragment.go
@@ -254,7 +254,7 @@ func (f *Fragment) SetTrunDataOffsets() {
 	}
 }
 
-// EncodeVerbatim - write fragment without trun optimiztion via writer
+// EncodeVerbatim - write fragment without trun optimization via writer
 func (f *Fragment) EncodeVerbatim(w io.Writer) error {
 	if f.Moof == nil {
 		return fmt.Errorf("moof not set in fragment")

--- a/mp4/free_test.go
+++ b/mp4/free_test.go
@@ -1,0 +1,13 @@
+package mp4
+
+import (
+	"testing"
+)
+
+func TestFree(t *testing.T) {
+	free := &FreeBox{Name: "free"}
+	boxDiffAfterEncodeAndDecode(t, free)
+
+	skip := &FreeBox{Name: "skip"}
+	boxDiffAfterEncodeAndDecode(t, skip)
+}

--- a/mp4/mediasegment.go
+++ b/mp4/mediasegment.go
@@ -113,3 +113,26 @@ func (s *MediaSegment) Fragmentify(timescale uint64, trex *TrexBox, duration uin
 	}
 	return outFragments, nil
 }
+
+// EncodeVerbatim - Write MediaSegment via writer with verbatim Fragments
+func (s *MediaSegment) EncodeVerbatim(w io.Writer) error {
+	if s.Styp != nil {
+		err := s.Styp.Encode(w)
+		if err != nil {
+			return err
+		}
+	}
+	if s.Sidx != nil {
+		err := s.Sidx.Encode(w)
+		if err != nil {
+			return err
+		}
+	}
+	for _, f := range s.Fragments {
+		err := f.EncodeVerbatim(w)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/mp4/mediasegment_test.go
+++ b/mp4/mediasegment_test.go
@@ -101,6 +101,59 @@ func TestMediaSegmentFragmentation(t *testing.T) {
 	}
 }
 
+func TestDoubleDecodeEncodeOptimize(t *testing.T) {
+	encodeVerbatim := false
+	inFile := "testdata/1.m4s"
+
+	fd, err := os.Open(inFile)
+	if err != nil {
+		t.Error(err)
+	}
+	defer fd.Close()
+
+	enc1 := decodeEncode(t, fd, encodeVerbatim)
+	buf1 := bytes.NewBuffer(enc1)
+	enc2 := decodeEncode(t, buf1, encodeVerbatim)
+	diff := deep.Equal(enc2, enc1)
+	if diff != nil {
+		t.Errorf("Second write gives diff %s", diff)
+	}
+}
+
+func TestDoubleDecodeEncodeNoOptimize(t *testing.T) {
+	encodeVerbatim := true
+	inFile := "testdata/1.m4s"
+
+	fd, err := os.Open(inFile)
+	if err != nil {
+		t.Error(err)
+	}
+	defer fd.Close()
+
+	enc1 := decodeEncode(t, fd, encodeVerbatim)
+	buf1 := bytes.NewBuffer(enc1)
+	enc2 := decodeEncode(t, buf1, encodeVerbatim)
+	diff := deep.Equal(enc2, enc1)
+	if diff != nil {
+		t.Errorf("Second write gives diff %s", diff)
+	}
+}
+
+func decodeEncode(t *testing.T, r io.Reader, encodeVerbatim bool) []byte {
+	f, err := DecodeFile(r)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf := bytes.Buffer{}
+	f.EncodeVerbatim = encodeVerbatim
+	err = f.Encode(&buf)
+	if err != nil {
+		t.Error(err)
+	}
+	return buf.Bytes()
+}
+
 func TestMoofEncrypted(t *testing.T) {
 
 	inFile := "testdata/moof_enc.m4s"

--- a/mp4/sgpd.go
+++ b/mp4/sgpd.go
@@ -70,7 +70,7 @@ func (b *SgpdBox) Size() uint64 {
 	// EntryCount: 4
 	// SampleCount + GroupDescriptionIndex : 8
 	// DescriptionLength: 4
-	// SampleGroupEntries: default or individual lengthsß
+	// SampleGroupEntries: default or individual lengths
 	size := uint64(boxHeaderSize + 4 + 4 + 4)
 	if b.Version >= 1 {
 		size += 4 // DefaultLength

--- a/mp4/trun.go
+++ b/mp4/trun.go
@@ -89,7 +89,7 @@ func CreateTrun(writeOrderNr uint32) *TrunBox {
 }
 
 // AddSampleDefaultValues - add values from tfhd and trex boxes if needed
-// Return total durationß
+// Return total duration
 func (t *TrunBox) AddSampleDefaultValues(tfhd *TfhdBox, trex *TrexBox) (totalDur uint64) {
 
 	var defaultSampleDuration uint32


### PR DESCRIPTION
Fix: The trun-tfhd optimization did not check if values have already been moved to tfhd.
Fix: Propagation of verbatim (non-optimized trun-tfhd) encoding for fragmented files.