### PR TITLE
feat: mp4ff-pslister for sps only

### DIFF
--- a/Versions.md
+++ b/Versions.md
@@ -2,6 +2,7 @@
 
 | Version | Highlight |
 | ------  | --------- |
+| 0.20.0 | feat: mp4ff-pslister better for hex SPS input |
 | 0.19.0 | fix: trun optimization, feat: mfra-related boxes |
 | 0.18.0 | feat: new mp4ff-wvttlister tool and fuller HEVC support |
 | 0.17.1 | fix: HEVC box decode and encode with test |

--- a/cmd/mp4ff-pslister/main.go
+++ b/cmd/mp4ff-pslister/main.go
@@ -36,7 +36,7 @@ var Usage = func(msg string) {
 }
 
 func main() {
-	verbose := flag.Bool("v", false, "Verbose output")
+	verbose := flag.Bool("v", false, "Verbose output -> details. On for hex input")
 	inFile := flag.String("i", "", "mp4 for bytestream file")
 	vpsHex := flag.String("vps", "", "VPS in hex format (HEVC only)")
 	spsHex := flag.String("sps", "", "SPS in hex format")
@@ -57,6 +57,11 @@ func main() {
 
 	if *vpsHex != "" {
 		*codec = "hevc"
+	}
+
+	if *spsHex != "" {
+		// Don't just print hex again
+		*verbose = true
 	}
 
 	var vpsNalus [][]byte


### PR DESCRIPTION
mp4ff-pslister can now parse SPS without PPS.
For hex input, verbose output is on by default.