### PR TITLE
fix: remove dead code for verbatim fragmented file

### DIFF
--- a/mp4/file.go
+++ b/mp4/file.go
@@ -218,24 +218,15 @@ func (f *File) Encode(w io.Writer) error {
 				return err
 			}
 		}
-		if !f.EncodeVerbatim {
-			for _, seg := range f.Segments {
-				err := seg.Encode(w)
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		}
-		// Fragmented and Verbatim. Don't optimize trun
 		for _, seg := range f.Segments {
-			err := seg.EncodeVerbatim(w)
+			err := seg.Encode(w)
 			if err != nil {
 				return err
 			}
 		}
+		return nil
 	}
-	// Progressive file
+	// Progressive file or verbatim
 	for _, b := range f.Children {
 		err := b.Encode(w)
 		if err != nil {


### PR DESCRIPTION
VerbatimEncode for a file should just encode all boxes as they are without taking segment structure into account. The code and the TestMediaSegmentFragmentation test in mediasegment_test.go already tests this, but some of the code is dead since it takes a half-step to use MediaSegment.EncodeVerbatim() and the comment at the end is wrong.

Triggered by #76 which suggests another change which uses  `MediaSegment.EncodeVerbatim()`. That way may have advantages if one has built a file oneself instead of parsing it into its current structure, but risks to miss some boxes that are children to File.