### PR TITLE
Remove extraneous extra byte in Hdlr size.

### DIFF
--- a/mp4/hdlr.go
+++ b/mp4/hdlr.go
@@ -77,7 +77,7 @@ func (b *HdlrBox) Type() string {
 
 // Size - calculated size of box
 func (b *HdlrBox) Size() uint64 {
-	return uint64(boxHeaderSize + 24 + len(b.Name) + 1)
+	return uint64(boxHeaderSize + 24 + len(b.Name))
 }
 
 // Encode - write box to w


### PR DESCRIPTION
Causing an issue in `meta` container parsing.

Added a log message because I ran into this error: `decode moov: decode meta: Non-matching children box sizes`.

<details> <summary> Logging Patch </summary>

```
// DecodeContainerChildren decodes a container box
func DecodeContainerChildren(hdr *boxHeader, startPos, endPos uint64, r io.Reader) ([]Box, error) {
	l := []Box{}
	pos := startPos
	for {
		fmt.Printf("parent: %v position: %d\n", hdr.name, pos)
		b, err := DecodeBox(pos, r)
		spew.Dump(b)
		if err == io.EOF {
			return l, nil
		}
		if err != nil {
			return l, err
		}
		l = append(l, b)
		pos += b.Size()
		fmt.Printf("pos: %d endPos: %d\n", pos, endPos)
		if pos == endPos {
			return l, nil
		} else if pos > endPos {
			return nil, fmt.Errorf("Non-matching children box sizes")
		}
	}
}
```

---

Output

```
pos: 152 endPos: 959
parent: moov position: 152
parent: meta position: 164
(*mp4.HdlrBox)(0xc0000664b0)({
 Version: (uint8) 0,
 Flags: (uint32) 0,
 PreDefined: (uint32) 0,
 HandlerType: (string) (len=4) "ID32",
 Name: (string) ""
})
pos: 197 endPos: 293
parent: meta position: 197
(*mp4.UnknownBox)(0xc000066510)({
 name: (string) (len=4) "ID32",
 size: (uint64) 97,
 notDecoded: ([]uint8) (len=89 cap=1536) {
  00000000  00 00 00 00 15 c7 49 44  33 04 00 00 00 00 00 49  |......ID3......I|
  00000010  50 52 49 56 00 00 00 3f  00 00 68 74 74 70 73 3a  |PRIV...?..https:|
  00000020  2f 2f 67 69 74 68 75 62  2e 63 6f 6d 2f 67 6f 6f  |//github.com/goo|
  00000030  67 6c 65 2f 73 68 61 6b  61 2d 70 61 63 6b 61 67  |gle/shaka-packag|
  00000040  65 72 00 76 32 2e 34 2e  33 2d 64 64 39 38 37 30  |er.v2.4.3-dd9870|
  00000050  30 2d 72 65 6c 65 61 73  65                       |0-release|
 }
})
pos: 294 endPos: 293
(interface {}) <nil>
decode moov: decode meta: Non-matching children box sizes
```

</details>

After this change, parsing worked as intended. This was with a shaka packager output as indicated in the `meta` information.