### PR TITLE
Correct four-cc for Schema Information child box

### DIFF
--- a/mp4/sinf.go
+++ b/mp4/sinf.go
@@ -19,7 +19,7 @@ func (b *SinfBox) AddChild(box Box) {
 		b.Frma = box.(*FrmaBox)
 	case "schm":
 		b.Schm = box.(*SchmBox)
-	case "dinf":
+	case "schi":
 		b.Schi = box.(*SchiBox)
 	}
 	b.Children = append(b.Children, box)


### PR DESCRIPTION
The incorrect four-cc value was provided, leading to the `Children` still being populated, but the helper accessor is left unpopulated.