### PR TITLE
Change/refactor: Replace file.EncodeVerbatim with more options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In the non-fragmented files, the members Ftyp, Moov, and Mdat are used.
 A fragmented `mp4.File` file can be a single init segment, one or more media segments, or a a
 combination of both like a CMAF track which renders into a playable one-track asset.
 
-The following high-level structures are used:
+For fragmented files, following high-level structures are used:
 
 * `InitSegment` contains an `ftyp` and `moov` box and provides the metadata for a fragmented files.
    It corresponds to a CMAF header
@@ -39,7 +39,7 @@ The typical child boxes are exported so that one can write paths such as
 
 to access the (only) trun box in a fragment.
 
-The codec currently supported are AVC/H.264 and AAC.
+The codecs currently supported are AVC/H.264, HEVC/H.265 and AAC.
 
 ## Usage for creating new fragmented files
 
@@ -104,18 +104,15 @@ adds a box to its slice of children boxes `Children`, but also sets a specific
 member reference such as `Tfdt`  to point to that box. If `Children` is manipulated
 directly, that link will not be valid.
 
-## Automatic settings of values on Fragment.Encode
-It is possible to optimize the `TrunBox` size by writing default values in `TfhdBox`.
-To do this, one must analyze if, for example, the duration of all samples is the same.
-This is done by the method `TrafBox.OptimizeTfhdTrun` which changes its children `Tfhd`and `Trun`.
-Since this will change the size of boxes, it is important that this function is called
-before `Encode` on any parent box of `Traf`. In particular, this method is called automatically
-when running `Fragment.Encode`.
-
-Another value which is automatically set by `Moof.Encode` is `MoofBox.Traf.Trun.DataOffset`.
-This value is the address of the first media sample relative to the start of the `MoofBox` start.
-It therefore depends on the size of `MoofBox` and is unknown until all values are in place so that
-it can be calculated. It is set to `MoofBox.Size()+8`.
+## Encoding modes and optimizations
+For fragmented files, one can choose to either encode all boxes in a file, or only code
+the ones which are inclueded in the init and media segments. The attribute that controls that
+is called `FragEncMode`.
+Another attribute `EncOptimize` controls possible optimizations of the file encoding process.
+Currently there is only one possible optimization called `OptimizeTrun`.
+It can reduce the size of the `TrunBox` by finding and writing default
+values in the `TfhdBox` and omitting the corresponding values from the `TrunBox`.
+Note that this may change the size of all ancestor boxes of `trun`.
 
 ## Sample Number Offset
 Following the ISOBMFF standard, sample numbers and other numbers start at 1 (one-based).

--- a/examples/multitrack/multitrack_test.go
+++ b/examples/multitrack/multitrack_test.go
@@ -80,7 +80,8 @@ func TestGetMultiTrackSamples(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	parsedMp4.EncodeMode = mp4.EncodeModeFileVerbatim
+	parsedMp4.FragEncMode = mp4.EncModeBoxTree
+	parsedMp4.EncOptimize = mp4.OptimizeNone
 	err = parsedMp4.Encode(&buf)
 	if err != nil {
 		t.Error(err)

--- a/examples/multitrack/multitrack_test.go
+++ b/examples/multitrack/multitrack_test.go
@@ -80,7 +80,7 @@ func TestGetMultiTrackSamples(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	parsedMp4.EncodeVerbatim = true
+	parsedMp4.EncodeMode = mp4.EncodeModeFileVerbatim
 	err = parsedMp4.Encode(&buf)
 	if err != nil {
 		t.Error(err)

--- a/mp4/mediasegment.go
+++ b/mp4/mediasegment.go
@@ -6,16 +6,18 @@ import (
 
 // MediaSegment - MP4 Media Segment
 type MediaSegment struct {
-	Styp      *StypBox
-	Sidx      *SidxBox // Sidx for a segment
-	Fragments []*Fragment
+	Styp        *StypBox
+	Sidx        *SidxBox // Sidx for a segment
+	Fragments   []*Fragment
+	EncOptimize EncOptimize
 }
 
 // NewMediaSegment - New empty MediaSegment
 func NewMediaSegment() *MediaSegment {
 	return &MediaSegment{
-		Styp:      CreateStyp(),
-		Fragments: []*Fragment{},
+		Styp:        CreateStyp(),
+		Fragments:   []*Fragment{},
+		EncOptimize: OptimizeNone,
 	}
 }
 
@@ -44,6 +46,7 @@ func (s *MediaSegment) Encode(w io.Writer) error {
 		}
 	}
 	for _, f := range s.Fragments {
+		f.EncOptimize = s.EncOptimize
 		err := f.Encode(w)
 		if err != nil {
 			return err
@@ -112,27 +115,4 @@ func (s *MediaSegment) Fragmentify(timescale uint64, trex *TrexBox, duration uin
 		}
 	}
 	return outFragments, nil
-}
-
-// EncodeVerbatim - Write MediaSegment via writer with verbatim Fragments
-func (s *MediaSegment) EncodeVerbatim(w io.Writer) error {
-	if s.Styp != nil {
-		err := s.Styp.Encode(w)
-		if err != nil {
-			return err
-		}
-	}
-	if s.Sidx != nil {
-		err := s.Sidx.Encode(w)
-		if err != nil {
-			return err
-		}
-	}
-	for _, f := range s.Fragments {
-		err := f.EncodeVerbatim(w)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/mp4/mediasegment_test.go
+++ b/mp4/mediasegment_test.go
@@ -35,7 +35,7 @@ func TestMediaSegmentFragmentation(t *testing.T) {
 	}
 
 	var bufInSeg bytes.Buffer
-	f.EncodeVerbatim = true
+	f.EncodeMode = EncodeModeSegmentVerbatim
 	err = f.Encode(&bufInSeg)
 	if err != nil {
 		t.Error(err)
@@ -102,7 +102,6 @@ func TestMediaSegmentFragmentation(t *testing.T) {
 }
 
 func TestDoubleDecodeEncodeOptimize(t *testing.T) {
-	encodeVerbatim := false
 	inFile := "testdata/1.m4s"
 
 	fd, err := os.Open(inFile)
@@ -111,9 +110,9 @@ func TestDoubleDecodeEncodeOptimize(t *testing.T) {
 	}
 	defer fd.Close()
 
-	enc1 := decodeEncode(t, fd, encodeVerbatim)
+	enc1 := decodeEncode(t, fd, EncodeModeTrunOptimize)
 	buf1 := bytes.NewBuffer(enc1)
-	enc2 := decodeEncode(t, buf1, encodeVerbatim)
+	enc2 := decodeEncode(t, buf1, EncodeModeTrunOptimize)
 	diff := deep.Equal(enc2, enc1)
 	if diff != nil {
 		t.Errorf("Second write gives diff %s", diff)
@@ -121,7 +120,7 @@ func TestDoubleDecodeEncodeOptimize(t *testing.T) {
 }
 
 func TestDoubleDecodeEncodeNoOptimize(t *testing.T) {
-	encodeVerbatim := true
+
 	inFile := "testdata/1.m4s"
 
 	fd, err := os.Open(inFile)
@@ -130,23 +129,23 @@ func TestDoubleDecodeEncodeNoOptimize(t *testing.T) {
 	}
 	defer fd.Close()
 
-	enc1 := decodeEncode(t, fd, encodeVerbatim)
+	enc1 := decodeEncode(t, fd, EncodeModeSegmentVerbatim)
 	buf1 := bytes.NewBuffer(enc1)
-	enc2 := decodeEncode(t, buf1, encodeVerbatim)
+	enc2 := decodeEncode(t, buf1, EncodeModeSegmentVerbatim)
 	diff := deep.Equal(enc2, enc1)
 	if diff != nil {
 		t.Errorf("Second write gives diff %s", diff)
 	}
 }
 
-func decodeEncode(t *testing.T, r io.Reader, encodeVerbatim bool) []byte {
+func decodeEncode(t *testing.T, r io.Reader, encMode FragFileEncodeMode) []byte {
 	f, err := DecodeFile(r)
 	if err != nil {
 		t.Error(err)
 	}
 
 	buf := bytes.Buffer{}
-	f.EncodeVerbatim = encodeVerbatim
+	f.EncodeMode = encMode
 	err = f.Encode(&buf)
 	if err != nil {
 		t.Error(err)
@@ -170,7 +169,7 @@ func TestMoofEncrypted(t *testing.T) {
 	}
 
 	var bufOut bytes.Buffer
-	f.EncodeVerbatim = true
+	f.EncodeMode = EncodeModeFileVerbatim
 	err = f.Encode(&bufOut)
 	if err != nil {
 		t.Error(err)
@@ -206,7 +205,7 @@ func BenchmarkDecodeEncode(b *testing.B) {
 		buf := bytes.NewBuffer(raw)
 		f, _ := DecodeFile(buf)
 		var bufInSeg bytes.Buffer
-		f.EncodeVerbatim = true
+		f.EncodeMode = EncodeModeSegmentVerbatim
 		_ = f.Encode(&bufInSeg)
 	}
 }


### PR DESCRIPTION
Triggered by PR #76, this is a new way with three options for encoding a fragmented mp4.File:

    EncodeModeTrunOptimize  = FragFileEncodeMode(0) // Optimize trun for size. May result in smaller encoded file
    EncodeModeSegmentVerbatim = FragFileEncodeMode(1) // Encode boxes that are part of Init and MediaSegments
    EncodeModeFileVerbatim  = FragFileEncodeMode(2) // Encode all boxes in file tree. Should reproduce a decoded file

Currently, the default mode is the first (EncodeModeTrunOptimize).
