### PR TITLE
Allow hdlr lacking null-termination of name

### DIFF
--- a/mp4/hdlr_test.go
+++ b/mp4/hdlr_test.go
@@ -1,6 +1,10 @@
 package mp4
 
-import "testing"
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
 
 func TestHdlr(t *testing.T) {
 	mediaTypes := []string{"video", "audio", "subtitle"}
@@ -9,5 +13,29 @@ func TestHdlr(t *testing.T) {
 		hdlr, err := CreateHdlr(m)
 		assertNoError(t, err)
 		boxDiffAfterEncodeAndDecode(t, hdlr)
+	}
+
+	for _, m := range mediaTypes {
+		hdlr, err := CreateHdlr(m)
+		hdlr.LacksNullTermination = true
+		assertNoError(t, err)
+		boxDiffAfterEncodeAndDecode(t, hdlr)
+	}
+}
+
+func TestHdlrDecodeMissingNullTermination(t *testing.T) {
+	hdlrExample := "0000002068646C72000000000000000049443332000000000000000000000000"
+	byteData, _ := hex.DecodeString(hdlrExample)
+	buf := bytes.NewBuffer(byteData)
+	box, err := DecodeBox(0, buf)
+	if err != nil {
+		t.Error(err)
+	}
+	hdlr := box.(*HdlrBox)
+	if hdlr.Size() != uint64(len(byteData)) {
+		t.Errorf("Got size %d instead of %d", hdlr.Size(), len(byteData))
+	}
+	if hdlr.Name != "" {
+		t.Errorf("Expected empty name, but got %s", hdlr.Name)
 	}
 }


### PR DESCRIPTION
Now handles cases where there is no null-termination in name string.
This is controlled via an attribute, so one can choose to encode without it.
To emphasize that it shall be there according to the spec, the parameter is called LacksNullTermination.