### PR TITLE
fix: make IsSyncSample thread safe

### DIFF
--- a/mp4/stss_test.go
+++ b/mp4/stss_test.go
@@ -27,6 +27,42 @@ func TestStss(t *testing.T) {
 			sample: 26,
 			isSync: true,
 		},
+		{
+			sample: 30,
+			isSync: false,
+		},
+	}
+
+	for _, test := range tests {
+		isSync := stss.IsSyncSample(test.sample)
+		if isSync != test.isSync {
+			t.Errorf("Sample %d has not write sync state", test.sample)
+		}
+	}
+}
+
+func TestStssEncodeDecode(t *testing.T) {
+	stss := &StssBox{
+		SampleNumber: []uint32{1, 26},
+	}
+
+	boxDiffAfterEncodeAndDecode(t, stss)
+}
+
+func TestStssNoSamples(t *testing.T) {
+	// The following pathological stss box has no samples
+	stss := &StssBox{
+		SampleNumber: nil,
+	}
+
+	tests := []struct {
+		sample uint32
+		isSync bool
+	}{
+		{
+			sample: 1,
+			isSync: false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Make stss.IsSyncSample() thread safe by changing creation of a map to a binary search.
Has the advantage that it works if the list of sync samples gets updated.

Solves #83.