### PR TITLE
Add fileDecMode to mp4.File

### DIFF
--- a/mp4/box.go
+++ b/mp4/box.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 )
 
 const (
@@ -228,7 +227,6 @@ func DecodeBox(startPos uint64, r io.Reader) (Box, error) {
 
 	d, ok := decoders[h.name]
 	remainingLength := int64(h.size) - int64(h.hdrlen)
-	log.Println(h.name, remainingLength, h.size, h.hdrlen)
 
 	if !ok {
 		b, err = DecodeUnknown(h, startPos, io.LimitReader(r, remainingLength))

--- a/mp4/box.go
+++ b/mp4/box.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 )
 
 const (
@@ -226,8 +227,8 @@ func DecodeBox(startPos uint64, r io.Reader) (Box, error) {
 	}
 
 	d, ok := decoders[h.name]
-
 	remainingLength := int64(h.size) - int64(h.hdrlen)
+	log.Println(h.name, remainingLength, h.size, h.hdrlen)
 
 	if !ok {
 		b, err = DecodeUnknown(h, startPos, io.LimitReader(r, remainingLength))

--- a/mp4/box.go
+++ b/mp4/box.go
@@ -226,6 +226,7 @@ func DecodeBox(startPos uint64, r io.Reader) (Box, error) {
 	}
 
 	d, ok := decoders[h.name]
+
 	remainingLength := int64(h.size) - int64(h.hdrlen)
 
 	if !ok {

--- a/mp4/file.go
+++ b/mp4/file.go
@@ -33,6 +33,7 @@ type File struct {
 	FragEncMode  EncFragFileMode // Determine how fragmented files are encoded
 	EncOptimize  EncOptimize     // Bit field with optimizations being done at encoding
 	isFragmented bool
+	fileDecMode  DecFileMode
 }
 
 type EncFragFileMode byte
@@ -40,6 +41,16 @@ type EncFragFileMode byte
 const (
 	EncModeSegment = EncFragFileMode(0) // Only encode boxes that are part of Init and MediaSegments
 	EncModeBoxTree = EncFragFileMode(1) // Encode all boxes in file tree
+)
+
+type DecFileMode byte
+
+const (
+	// DecModeLazyMdat doesn't not read Mdat data into memory,
+	// which means the decoding process requires less memory and faster.
+	DecModeLazyMdat DecFileMode = iota
+	// DecModeNormal read Mdat data into memory during file decoding.
+	DecModeNormal
 )
 
 type EncOptimize uint32
@@ -105,47 +116,34 @@ func (f *File) AddMediaSegment(m *MediaSegment) {
 }
 
 // DecodeFile - parse and decode a file from reader r
-func DecodeFile(r io.Reader) (*File, error) {
+func DecodeFile(r io.Reader, options ...Option) (*File, error) {
 	f := NewFile()
+
+	// apply options
+	f.ApplyOptions(options...)
+
 	var boxStartPos uint64 = 0
 	lastBoxType := ""
 
-LoopBoxes:
-	for {
-		box, err := DecodeBox(boxStartPos, r)
-		if err == io.EOF {
-			break LoopBoxes
+	var rs io.ReadSeeker
+	if f.fileDecMode == DecModeLazyMdat {
+		ok := false
+		rs, ok = r.(io.ReadSeeker)
+		if !ok {
+			return nil, fmt.Errorf("expecting readseeker when decoding file lazily, but got %T", r)
 		}
-		if err != nil {
-			return nil, err
-		}
-		boxType, boxSize := box.Type(), box.Size()
-		if err != nil {
-			return nil, err
-		}
-		if boxType == "mdat" {
-			if f.isFragmented {
-				if lastBoxType != "moof" {
-					return nil, fmt.Errorf("Does not support %v between moof and mdat", lastBoxType)
-				}
-			}
-		}
-		f.AddChild(box, boxStartPos)
-		lastBoxType = boxType
-		boxStartPos += boxSize
 	}
-	return f, nil
-}
-
-// DecodeFileLazily - parse and decode a file from reader r
-func DecodeFileLazily(r io.ReadSeeker) (*File, error) {
-	f := NewFile()
-	var boxStartPos uint64 = 0
-	lastBoxType := ""
 
 LoopBoxes:
 	for {
-		box, err := DecodeBoxLazyMdat(boxStartPos, r)
+		var box Box
+		var err error
+		switch f.fileDecMode {
+		case DecModeLazyMdat:
+			box, err = DecodeBoxLazyMdat(boxStartPos, rs)
+		default:
+			box, err = DecodeBox(boxStartPos, r)
+		}
 		if err == io.EOF {
 			break LoopBoxes
 		}
@@ -331,4 +329,25 @@ func (f *File) LastSegment() *MediaSegment {
 // IsFragmented - is file made of multiple segments (Mp4 fragments)
 func (f *File) IsFragmented() bool {
 	return f.isFragmented
+}
+
+// ApplyOptions - applies options for decoding or encoding a file
+func (f *File) ApplyOptions(opts ...Option) {
+	for _, opt := range opts {
+		opt(f)
+	}
+}
+
+// Option is function signature of file options.
+// The design follows functional options pattern.
+type Option func(f *File)
+
+// WithEncodeMode sets up EncFragFileMode
+func WithEncodeMode(mode EncFragFileMode) Option {
+	return func(f *File) { f.FragEncMode = mode }
+}
+
+// WithDecodeMode sets up DecFileMode
+func WithDecodeMode(mode DecFileMode) Option {
+	return func(f *File) { f.fileDecMode = mode }
 }

--- a/mp4/file_test.go
+++ b/mp4/file_test.go
@@ -1,0 +1,64 @@
+package mp4
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDecodeFileWithLazyMdatOption(t *testing.T) {
+
+	// load a segment
+	file, err := os.Open("./testdata/1.m4s")
+	if err != nil {
+		t.Error(err)
+	}
+
+	parsedFile, err := DecodeFile(file, WithDecodeMode(DecModeLazyMdat))
+	if err != nil {
+		t.Error(err)
+	}
+
+	for _, seg := range parsedFile.Segments {
+		for _, frag := range seg.Fragments {
+			if frag.Mdat.decLazyDataSize == 0 {
+				t.Error("decLazyDataSize is expected to be greater than 0")
+			}
+			if frag.Mdat.readSeeker == nil {
+				t.Error("Mdat readSeeker is expected to be non-nil")
+			}
+			if frag.Mdat.Data != nil {
+				t.Error("Mdat Data is expected to be nil")
+			}
+		}
+	}
+
+}
+
+func TestDecodeFileWithNoLazyMdatOption(t *testing.T) {
+
+	// load a segment
+	file, err := os.Open("./testdata/1.m4s")
+	if err != nil {
+		t.Error(err)
+	}
+
+	parsedFile, err := DecodeFile(file)
+	if err != nil {
+		t.Error(err)
+	}
+
+	for _, seg := range parsedFile.Segments {
+		for _, frag := range seg.Fragments {
+			if frag.Mdat.decLazyDataSize != 0 {
+				t.Error("decLazyDataSize is expected to be 0")
+			}
+			if frag.Mdat.readSeeker != nil {
+				t.Error("Mdat readSeeker is expected to be nil")
+			}
+			if frag.Mdat.Data == nil || len(frag.Mdat.Data) == 0 {
+				t.Error("Mdat Data is expected to be non-nil")
+			}
+		}
+	}
+
+}

--- a/mp4/mdat.go
+++ b/mp4/mdat.go
@@ -1,6 +1,8 @@
 package mp4
 
 import (
+	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 )
@@ -12,6 +14,7 @@ type MdatBox struct {
 	Data            []byte
 	decLazyDataSize uint64
 	LargeSize       bool
+	readSeeker      io.ReadSeeker
 }
 
 const maxNormalPayloadSize = (1 << 32) - 1 - 8
@@ -23,13 +26,13 @@ func DecodeMdat(hdr *boxHeader, startPos uint64, r io.Reader) (Box, error) {
 		return nil, err
 	}
 	largeSize := hdr.hdrlen > boxHeaderSize
-	return &MdatBox{startPos, data, uint64(len(data)), largeSize}, nil
+	return &MdatBox{startPos, data, uint64(len(data)), largeSize, nil}, nil
 }
 
 func DecodeMdatLazily(hdr *boxHeader, startPos uint64) (Box, error) {
 	largeSize := hdr.hdrlen > boxHeaderSize
 	decLazyDataSize := hdr.size - uint64(hdr.hdrlen)
-	return &MdatBox{startPos, nil, decLazyDataSize, largeSize}, nil
+	return &MdatBox{startPos, nil, decLazyDataSize, largeSize, nil}, nil
 }
 
 // Type - return box type
@@ -83,4 +86,43 @@ func (m *MdatBox) HeaderSize() uint64 {
 // PayloadAbsoluteOffset - position of mdat payload start (works after header)
 func (m *MdatBox) PayloadAbsoluteOffset() uint64 {
 	return m.StartPos + m.HeaderSize()
+}
+
+// AddReadSeeker - add readseeker to Mdat box.
+// When a file is decoded lazily, the Mdat Data byte slice is nil
+// and this readseeker is to read data whenever the data is needed.
+func (m *MdatBox) AddReadSeeker(rs io.ReadSeeker) {
+	m.readSeeker = rs
+}
+
+// ReadData reads Mdat data specified by the start and size.
+// Input argument start is the postion relative to the start of a file.
+func (m *MdatBox) ReadData(start, size int64) ([]byte, error) {
+	// The Mdat box was decoded lazily
+	if m.decLazyDataSize > 0 {
+		if m.readSeeker == nil {
+			return nil, errors.New("lazy mdat mode expects readseeker to read data")
+		}
+		_, err := m.readSeeker.Seek(start, io.SeekStart)
+		if err != nil {
+			return nil, fmt.Errorf("unable to seek to %d", start)
+		}
+
+		buf := make([]byte, size)
+		n, err := m.readSeeker.Read(buf)
+		if err != nil {
+			return nil, err
+		}
+		if int64(n) != size {
+			return nil, fmt.Errorf("expect to read %d bytes, but only read %d bytes", size, n)
+		}
+		return buf, nil
+	}
+
+	// All Mdat Data is in memory
+	mdatPayloadStart := m.PayloadAbsoluteOffset()
+	offsetInMdatData := uint64(start) - mdatPayloadStart
+
+	return m.Data[offsetInMdatData : offsetInMdatData+uint64(size)], nil
+
 }

--- a/mp4/mdat_test.go
+++ b/mp4/mdat_test.go
@@ -2,8 +2,6 @@ package mp4
 
 import (
 	"bytes"
-	"encoding/hex"
-	"log"
 	"sync"
 	"testing"
 
@@ -117,14 +115,12 @@ func TestReadData_LazyMdatMode(t *testing.T) {
 		t.Error(err)
 	}
 
-	// test ReadData
+	// test ReadData with provided ReadSeeker
 	lazyMdat := &MdatBox{
 		StartPos:        0,
 		decLazyDataSize: 7,
 		mu:              &sync.Mutex{},
 	}
-
-	log.Println(hex.Dump(buf.Bytes()))
 
 	readSeeker := bytes.NewReader(buf.Bytes())
 	lazyMdat.setReadSeeker(readSeeker)


### PR DESCRIPTION
- Add fileDecMode to mp4.File 
- Use functional options to set up decode and encode modes. 
- Remove `DecodeFileLazily` func 

The PR also includes:
- Changes in mdat.go 
    - Add `AddReadSeeker` method to MdatBox. This method adds a necessary readseeker to MdatBox to read Mdat data when the file is decoded lazily.
    - Add `ReadData` method to MdatBox to read data 
        - if `decLazyDataSize` is greater than 0, which means the file is decoded lazily, so a readseeker is needed to retrieve data. 
        - otherwise, Mdat data is in memory and can be retrieved directly.

