### PR TITLE
fix: encode non-optimized segment in EncModeSegment and broken test

### DIFF
--- a/mp4/file.go
+++ b/mp4/file.go
@@ -280,13 +280,13 @@ func (f *File) Encode(w io.Writer) error {
 					return err
 				}
 			}
-			if f.EncOptimize&OptimizeTrun != 0 {
-				for _, seg := range f.Segments {
+			for _, seg := range f.Segments {
+				if f.EncOptimize&OptimizeTrun != 0 {
 					seg.EncOptimize = f.EncOptimize
-					err := seg.Encode(w)
-					if err != nil {
-						return err
-					}
+				}
+				err := seg.Encode(w)
+				if err != nil {
+					return err
 				}
 			}
 		case EncModeBoxTree:

--- a/mp4/mediasegment_test.go
+++ b/mp4/mediasegment_test.go
@@ -125,16 +125,19 @@ func TestDoubleDecodeEncodeNoOptimize(t *testing.T) {
 
 	inFile := "testdata/1.m4s"
 
-	fd, err := os.Open(inFile)
+	data, err := ioutil.ReadFile(inFile)
 	if err != nil {
 		t.Error(err)
 	}
-	defer fd.Close()
-
-	enc1 := decodeEncode(t, fd, OptimizeNone)
+	buf0 := bytes.NewBuffer(data)
+	enc1 := decodeEncode(t, buf0, OptimizeNone)
+	diff := deep.Equal(enc1, data)
+	if diff != nil {
+		t.Errorf("First encode gives diff %s", diff)
+	}
 	buf1 := bytes.NewBuffer(enc1)
 	enc2 := decodeEncode(t, buf1, OptimizeNone)
-	diff := deep.Equal(enc2, enc1)
+	diff = deep.Equal(enc2, enc1)
 	if diff != nil {
 		t.Errorf("Second write gives diff %s", diff)
 	}


### PR DESCRIPTION
Fixing bug that was introduced in v0.23.0 with encoding modes.
Encode of segmented files without optimization did not give any output.