### PR TITLE
fix: stts handling of variable sample duration

### DIFF
--- a/mp4/stts.go
+++ b/mp4/stts.go
@@ -160,8 +160,15 @@ func (b *SttsBox) GetSampleNrAtTime(sampleStartTime uint64) (sampleNr uint32, er
 	for i := 0; i < len(b.SampleCount); i++ {
 		timeDelta := uint64(b.SampleTimeDelta[i])
 		if sampleStartTime < accTime+uint64(b.SampleCount[i])*timeDelta {
-			return accNr + uint32((sampleStartTime-accTime)/timeDelta) + 1, nil
+			relTime := (sampleStartTime - accTime)
+			nrInInterval := relTime / timeDelta
+			if relTime%timeDelta != 0 { // If not exact, increase number to next sample
+				nrInInterval++
+			}
+			return accNr + uint32(nrInInterval) + 1, nil
 		}
+		accNr += b.SampleCount[i]
+		accTime += timeDelta * uint64(b.SampleCount[i])
 	}
-	return 0, fmt.Errorf("no matching sample found")
+	return 0, fmt.Errorf("no matching sample found for time=%d", sampleStartTime)
 }

--- a/mp4/stts_test.go
+++ b/mp4/stts_test.go
@@ -9,3 +9,45 @@ func TestSttsEncDec(t *testing.T) {
 	}
 	boxDiffAfterEncodeAndDecode(t, &stts)
 }
+
+func TestGetSampleNrAtTime(t *testing.T) {
+
+	stts := SttsBox{
+		SampleCount:     []uint32{3, 2},
+		SampleTimeDelta: []uint32{10, 14},
+	}
+
+	testCases := []struct {
+		startTime   uint64
+		sampleNr    uint32
+		expectError bool
+	}{
+		{0, 1, false},
+		{1, 2, false},
+		{10, 2, false},
+		{20, 3, false},
+		{30, 4, false},
+		{31, 5, false},
+		{43, 5, false},
+		{44, 5, false},
+		{45, 6, false},
+		{57, 6, false},
+		{58, 0, true},
+	}
+
+	for _, tc := range testCases {
+		gotNr, err := stts.GetSampleNrAtTime(tc.startTime)
+		if tc.expectError {
+			if err == nil {
+				t.Errorf("Did not get error for startTime %d", tc.startTime)
+			}
+			continue
+		}
+		if err != nil {
+			t.Error(err)
+		}
+		if gotNr != tc.sampleNr {
+			t.Errorf("Got sampleNr %d instead of %d for %d", gotNr, tc.sampleNr, tc.startTime)
+		}
+	}
+}


### PR DESCRIPTION
Got an example of a surveillance video as a progressive mp4 file with variable frame rate in #94.
The SttsBox could not handle that, but that is now fixed.