### PR TITLE
Fix stts GetDecodeTime

### DIFF
--- a/mp4/ctts.go
+++ b/mp4/ctts.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"io"
 	"io/ioutil"
-	"log"
 )
 
 // CttsBox - Composition Time to Sample Box (ctts - optional)
@@ -73,9 +72,9 @@ func (b *CttsBox) Encode(w io.Writer) error {
 // GetCompositionTimeOffset - composition time offset for (one-based) sampleNr in track timescale
 func (b *CttsBox) GetCompositionTimeOffset(sampleNr uint32) int32 {
 	if sampleNr == 0 {
-		// This is bad index input. Should not happen
-		log.Print("ERROR: CttsBox.GetCompositionTimeOffset called with sampleNr == 0, although one-based")
-		return 0
+		// This is bad index input. Should never happen
+		panic("CttsBox.GetCompositionTimeOffset called with sampleNr == 0, although one-based")
+
 	}
 	sampleNr-- // one-based
 	for i := range b.SampleCount {

--- a/mp4/ctts_test.go
+++ b/mp4/ctts_test.go
@@ -12,3 +12,31 @@ func TestCtts(t *testing.T) {
 
 	boxDiffAfterEncodeAndDecode(t, ctts)
 }
+
+func TestGetCompositionTimeOffset(t *testing.T) {
+	ctts := &CttsBox{
+		Version:      0,
+		Flags:        0,
+		SampleCount:  []uint32{2, 1, 3, 1},
+		SampleOffset: []int32{0, -1000, 1000, 0},
+	}
+
+	testCases := []struct {
+		sampleNr    uint32
+		expectedCTO int32
+	}{
+		{1, 0},
+		{2, 0},
+		{3, -1000},
+		{4, 1000},
+		{5, 1000},
+		{6, 1000},
+		{7, 0},
+	}
+	for idx, tc := range testCases {
+		gotCTO := ctts.GetCompositionTimeOffset(tc.sampleNr)
+		if gotCTO != tc.expectedCTO {
+			t.Errorf("test case %d: got cto %d instead of %d for sampleNr %d", idx, gotCTO, tc.expectedCTO, tc.sampleNr)
+		}
+	}
+}

--- a/mp4/stts.go
+++ b/mp4/stts.go
@@ -81,18 +81,19 @@ func (b *SttsBox) GetDecodeTime(sampleNr uint32) (decTime uint64, dur uint32) {
 		log.Print("ERROR: SttsBox.GetDecodeTime called with sampleNr == 0, although one-based")
 		return 0, 1
 	}
-	sampleNr-- // one-based
+	samplesRemaining := sampleNr - 1
 	decTime = 0
 	i := 0
-	for sampleNr > 0 && i < len(b.SampleCount) {
+	for {
 		dur = b.SampleTimeDelta[i]
-
-		if sampleNr >= b.SampleCount[i] {
+		if samplesRemaining >= b.SampleCount[i] {
 			decTime += uint64(b.SampleCount[i] * dur)
-			sampleNr -= b.SampleCount[i]
+			samplesRemaining -= b.SampleCount[i]
 		} else {
-			decTime += uint64(sampleNr * dur)
-			sampleNr = 0
+			if samplesRemaining > 0 {
+				decTime += uint64(samplesRemaining * dur)
+			}
+			break
 		}
 		i++
 	}

--- a/mp4/stts.go
+++ b/mp4/stts.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"time"
 )
 
@@ -77,9 +76,8 @@ func (b *SttsBox) GetTimeCode(sample, timescale uint32) time.Duration {
 // GetDecodeTime - decode time and duration for (one-based) sampleNr in track timescale
 func (b *SttsBox) GetDecodeTime(sampleNr uint32) (decTime uint64, dur uint32) {
 	if sampleNr == 0 {
-		// This is bad index input. Should not happen
-		log.Print("ERROR: SttsBox.GetDecodeTime called with sampleNr == 0, although one-based")
-		return 0, 1
+		// This is bad index input. Should never happen
+		panic("SttsBox.GetDecodeTime called with sampleNr == 0, although one-based")
 	}
 	samplesRemaining := sampleNr - 1
 	decTime = 0
@@ -103,9 +101,8 @@ func (b *SttsBox) GetDecodeTime(sampleNr uint32) (decTime uint64, dur uint32) {
 // GetDur - get dur for a specific sample
 func (b *SttsBox) GetDur(sampleNr uint32) (dur uint32) {
 	if sampleNr == 0 {
-		// This is bad index input. Should not happen
-		log.Print("ERROR: SttsBox.GetDur called with sampleNr == 0, although one-based")
-		return 0
+		// This is bad index input. Should never happen
+		panic("SttsBox.GetDur called with sampleNr == 0, although one-based")
 	}
 	sampleNr-- // one-based -> zero-based
 	i := 0

--- a/mp4/stts_test.go
+++ b/mp4/stts_test.go
@@ -51,3 +51,30 @@ func TestGetSampleNrAtTime(t *testing.T) {
 		}
 	}
 }
+
+func TestGetDecodeTime(t *testing.T) {
+	stts := SttsBox{
+		SampleCount:     []uint32{3, 1, 1},
+		SampleTimeDelta: []uint32{1024, 1025, 1024},
+	}
+
+	testCases := []struct {
+		sampleNr    uint32
+		expectedDec uint64
+		expectedDur uint32
+	}{
+		{1, 0, 1024},
+		{3, 2 * 1024, 1024},
+		{4, 3 * 1024, 1025},
+		{5, 3*1024 + 1025, 1024},
+	}
+	for idx, tc := range testCases {
+		gotDec, gotDur := stts.GetDecodeTime(tc.sampleNr)
+		if gotDec != tc.expectedDec {
+			t.Errorf("test case %d: got dec %d instead of %d for sampleNr %d", idx, gotDec, tc.expectedDec, tc.sampleNr)
+		}
+		if gotDur != tc.expectedDur {
+			t.Errorf("test case %d: got dur %d instead of %d for sampleNr %d", idx, gotDur, tc.expectedDur, tc.sampleNr)
+		}
+	}
+}


### PR DESCRIPTION
Fix algorithm in GetDecodeTime to return correct values as verified by tests provided in #100.

Also change log of zero sampleNr argument into panic, since that should be a programmatic error, rather than a parsing error.