### PR TITLE
More efficient data storage for stsc box

### DIFF
--- a/mp4/initsegment_test.go
+++ b/mp4/initsegment_test.go
@@ -61,7 +61,7 @@ func TestInitSegmentParsing(t *testing.T) {
 
 }
 
-func TestMoovParsingWithBtrtParsing(t *testing.T) {
+func TestMoovParsingWithBtrt(t *testing.T) {
 	initFile := "testdata/init_prog.mp4"
 	initDumpGoldenPath := "testdata/golden_init_prog_mp4_dump.txt"
 	f, err := parseInitFile(initFile)

--- a/mp4/sidx.go
+++ b/mp4/sidx.go
@@ -15,7 +15,8 @@ aligned(8) class SegmentIndexBox extends FullBox(‘sidx’, version, 0) {
 		unsigned int(32) earliest_presentation_time;
 		unsigned int(32) first_offset;
 	} else {
-		unsigned int(64) earliest_presentation_time; unsigned int(64) first_offset;
+		unsigned int(64) earliest_presentation_time;
+		unsigned int(64) first_offset;
 	}
 	unsigned int(16) reserved = 0;
 	unsigned int(16) reference_count;

--- a/mp4/stsc_test.go
+++ b/mp4/stsc_test.go
@@ -72,10 +72,10 @@ func TestStsc(t *testing.T) {
 
 	t.Run("encode and decode", func(t *testing.T) {
 		stsc := &StscBox{
-			FirstChunk:          []uint32{1, 3},
-			SamplesPerChunk:     []uint32{256, 1000},
-			SampleDescriptionID: []uint32{1, 1},
+			FirstChunk:      []uint32{1, 3},
+			SamplesPerChunk: []uint32{256, 1000},
 		}
+		stsc.SetSingleSampleDescriptionID(1)
 		boxDiffAfterEncodeAndDecode(t, stsc)
 	})
 }
@@ -126,7 +126,7 @@ func TestGetChunk(t *testing.T) {
 	stsc := &StscBox{
 		FirstChunk:          []uint32{1, 3},
 		SamplesPerChunk:     []uint32{256, 1000},
-		SampleDescriptionID: []uint32{1, 1},
+		SampleDescriptionID: []uint32{1, 2},
 	}
 
 	testCases := []struct {


### PR DESCRIPTION
Make storage of data more efficient in stsc box.
This is in particular important for cases with big progressive files with very short (e.g. 1-frame) chunks.