### PR TITLE
Remove sample pointers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,38 @@
-all: mp4ff-info mp4ff-nallister mp4ff-pslister mp4ff-wvttlister
+.PHONY: all
+all: test check mp4ff-info mp4ff-nallister mp4ff-pslister mp4ff-wvttlister examples
+
+.PHONY: prepare
+prepare:
+	go mod vendor
 
 mp4ff-info mp4ff-nallister mp4ff-pslister mp4ff-wvttlister:
-	go build -ldflags "-X github.com/edgeware/mp4ff/mp4.commitVersion=$$(git describe --tags HEAD) -X github.com/edgeware/mp4ff/mp4.commitDate=$$(git log -1 --format=%ct)" -o out/$@ cmd/$@/main.go
+	go build -ldflags "-X github.com/edgeware/mp4ff/mp4.commitVersion=$$(git describe --tags HEAD) -X github.com/edgeware/mp4ff/mp4.commitDate=$$(git log -1 --format=%ct)" -o out/$@ ./cmd/$@/main.go
+
+.PHONY: examples
+examples: initcreator multitrack resegmenter segmenter
+
+initcreator multitrack resegmenter segmenter:
+	go build -o examples-out/$@  ./examples/$@
+
+.PHONY: test
+test: prepare
+	go test ./...
+
+.PHONY: coverage
+coverage:
+	# Ignore (allow) packages without any tests
+	set -o pipefail
+	go test ./... -coverprofile coverage.out
+	set +o pipefail
+	go tool cover -html=coverage.out -o coverage.html
+
+.PHONY: check
+check: prepare
+	golangci-lint run
 
 clean:
 	rm -f out/*
+	rm -r examples-out/*
 
 install: all
 	cp out/* $(GOPATH)/bin/

--- a/cmd/mp4ff-nallister/main.go
+++ b/cmd/mp4ff-nallister/main.go
@@ -159,7 +159,7 @@ func parseFragmentedMp4(f *mp4.File, maxNrSamples int, codec string) error {
 			codec = "hevc"
 		}
 	}
-	iSamples := make([]*mp4.FullSample, 0)
+	iSamples := make([]mp4.FullSample, 0)
 	for _, iSeg := range f.Segments {
 		for _, iFrag := range iSeg.Fragments {
 			fSamples, err := iFrag.GetFullSamples(nil)

--- a/cmd/mp4ff-wvttlister/main.go
+++ b/cmd/mp4ff-wvttlister/main.go
@@ -164,7 +164,7 @@ func parseFragmentedMp4(f *mp4.File, trackID uint32, maxNrSamples int) error {
 			}
 		}
 	}
-	iSamples := make([]*mp4.FullSample, 0)
+	iSamples := make([]mp4.FullSample, 0)
 	for _, iSeg := range f.Segments {
 		for _, iFrag := range iSeg.Fragments {
 			fSamples, err := iFrag.GetFullSamples(wvttTrex)

--- a/examples/multitrack/main.go
+++ b/examples/multitrack/main.go
@@ -25,7 +25,7 @@ type Track struct {
 	timeScale uint64
 	trak      *mp4.TrakBox
 	trex      *mp4.TrexBox
-	samples   []*mp4.FullSample
+	samples   []mp4.FullSample
 }
 
 func main() {

--- a/examples/resegmenter/resegment.go
+++ b/examples/resegmenter/resegment.go
@@ -12,7 +12,7 @@ func Resegment(in *mp4.File, chunkDur uint64) (*mp4.File, error) {
 	if !in.IsFragmented() {
 		log.Fatalf("Non-segmented input file not supported")
 	}
-	var iSamples []*mp4.FullSample
+	var iSamples []mp4.FullSample
 
 	for _, iSeg := range in.Segments {
 		for _, iFrag := range iSeg.Fragments {

--- a/examples/segmenter/segmenter.go
+++ b/examples/segmenter/segmenter.go
@@ -122,9 +122,9 @@ func (s *Segmenter) MakeMuxedInitSegment() (*mp4.InitSegment, error) {
 }
 
 // GetFullSamplesForInterval - get slice of fullsamples with numbers startSampleNr to endSampleNr (inclusive)
-func (s *Segmenter) GetFullSamplesForInterval(mp4f *mp4.File, tr *Track, startSampleNr, endSampleNr uint32, rs io.ReadSeeker) ([]*mp4.FullSample, error) {
+func (s *Segmenter) GetFullSamplesForInterval(mp4f *mp4.File, tr *Track, startSampleNr, endSampleNr uint32, rs io.ReadSeeker) ([]mp4.FullSample, error) {
 	stbl := tr.inTrak.Mdia.Minf.Stbl
-	samples := make([]*mp4.FullSample, 0, endSampleNr-startSampleNr+1)
+	samples := make([]mp4.FullSample, 0, endSampleNr-startSampleNr+1)
 	mdat := mp4f.Mdat
 	mdatPayloadStart := mdat.PayloadAbsoluteOffset()
 	for sampleNr := startSampleNr; sampleNr <= endSampleNr; sampleNr++ {
@@ -183,15 +183,15 @@ func (s *Segmenter) GetFullSamplesForInterval(mp4f *mp4.File, tr *Track, startSa
 		}
 
 		//fmt.Printf("Sample %d times %d %d, sync %v, offset %d, size %d\n", sampleNr, decTime, cto, isSync, offset, size)
-		samples = append(samples, &sc)
+		samples = append(samples, sc)
 	}
 	return samples, nil
 }
 
 // GetSamplesForInterval - get slice of samples with numbers startSampleNr to endSampleNr (inclusive)
-func (s *Segmenter) GetSamplesForInterval(mp4f *mp4.File, trak *mp4.TrakBox, startSampleNr, endSampleNr uint32) ([]*mp4.Sample, error) {
+func (s *Segmenter) GetSamplesForInterval(mp4f *mp4.File, trak *mp4.TrakBox, startSampleNr, endSampleNr uint32) ([]mp4.Sample, error) {
 	stbl := trak.Mdia.Minf.Stbl
-	samples := make([]*mp4.Sample, 0, endSampleNr-startSampleNr+1)
+	samples := make([]mp4.Sample, 0, endSampleNr-startSampleNr+1)
 	for sampleNr := startSampleNr; sampleNr <= endSampleNr; sampleNr++ {
 		size := stbl.Stsz.GetSampleSize(int(sampleNr))
 		dur := stbl.Stts.GetDur(sampleNr)
@@ -211,7 +211,7 @@ func (s *Segmenter) GetSamplesForInterval(mp4f *mp4.File, trak *mp4.TrakBox, sta
 		}
 
 		//fmt.Printf("Sample %d times %d %d, sync %v, offset %d, size %d\n", sampleNr, decTime, cto, isSync, offset, size)
-		samples = append(samples, &sc)
+		samples = append(samples, sc)
 	}
 	return samples, nil
 }

--- a/mp4/fragment.go
+++ b/mp4/fragment.go
@@ -175,6 +175,21 @@ func (f *Fragment) AddSample(s Sample, baseMediaDecodeTime uint64) {
 	f.Mdat.lazyDataSize += uint64(s.Size)
 }
 
+// AddSamples - add a slice of Sample to the first (and only) trun of a track
+func (f *Fragment) AddSamples(ss []Sample, baseMediaDecodeTime uint64) {
+	trun := f.Moof.Traf.Trun
+	if trun.SampleCount() == 0 {
+		tfdt := f.Moof.Traf.Tfdt
+		tfdt.SetBaseMediaDecodeTime(baseMediaDecodeTime)
+	}
+	trun.AddSamples(ss)
+	var accSize uint64 = 0
+	for _, s := range ss {
+		accSize += uint64(s.Size)
+	}
+	f.Mdat.lazyDataSize += accSize
+}
+
 // AddSampleToTrack - allows for adding samples to any track
 // New trun boxes will be created if latest trun of fragment is not in this track
 // baseMediaDecodeTime will be used only for first sample in a trun

--- a/mp4/fragment.go
+++ b/mp4/fragment.go
@@ -90,7 +90,7 @@ func (f *Fragment) Size() uint64 {
 }
 
 // GetFullSamples - Get full samples including media and accumulated time
-func (f *Fragment) GetFullSamples(trex *TrexBox) ([]*FullSample, error) {
+func (f *Fragment) GetFullSamples(trex *TrexBox) ([]FullSample, error) {
 	moof := f.Moof
 	mdat := f.Mdat
 	//seqNr := moof.Mfhd.SequenceNumber
@@ -112,7 +112,7 @@ func (f *Fragment) GetFullSamples(trex *TrexBox) ([]*FullSample, error) {
 	tfhd := traf.Tfhd
 	baseTime := traf.Tfdt.BaseMediaDecodeTime
 	moofStartPos := moof.StartPos
-	var samples []*FullSample
+	var samples []FullSample
 	for _, trun := range traf.Truns {
 		totalDur := trun.AddSampleDefaultValues(tfhd, trex)
 		var baseOffset uint64
@@ -138,21 +138,21 @@ func (f *Fragment) GetFullSamples(trex *TrexBox) ([]*FullSample, error) {
 
 // AddFullSample - add a full sample to the first (and only) trun of a track
 // AddFullSampleToTrack is the more general function
-func (f *Fragment) AddFullSample(s *FullSample) {
+func (f *Fragment) AddFullSample(s FullSample) {
 	trun := f.Moof.Traf.Trun
 	if trun.SampleCount() == 0 {
 		tfdt := f.Moof.Traf.Tfdt
 		tfdt.SetBaseMediaDecodeTime(s.DecodeTime)
 	}
-	trun.AddSample(&s.Sample)
+	trun.AddSample(s.Sample)
 	mdat := f.Mdat
 	mdat.AddSampleData(s.Data)
 }
 
 // AddFullSampleToTrack - allows for adding samples to any track
 // New trun boxes will be created if latest trun of fragment is not in this track
-func (f *Fragment) AddFullSampleToTrack(s *FullSample, trackID uint32) error {
-	err := f.AddSampleToTrack(&s.Sample, trackID, s.DecodeTime)
+func (f *Fragment) AddFullSampleToTrack(s FullSample, trackID uint32) error {
+	err := f.AddSampleToTrack(s.Sample, trackID, s.DecodeTime)
 	if err != nil {
 		return err
 	}
@@ -165,7 +165,7 @@ func (f *Fragment) AddFullSampleToTrack(s *FullSample, trackID uint32) error {
 
 // AddSample - add a sample to the first (and only) trun of a track
 // AddSampleToTrack is the more general function
-func (f *Fragment) AddSample(s *Sample, baseMediaDecodeTime uint64) {
+func (f *Fragment) AddSample(s Sample, baseMediaDecodeTime uint64) {
 	trun := f.Moof.Traf.Trun
 	if trun.SampleCount() == 0 {
 		tfdt := f.Moof.Traf.Tfdt
@@ -178,7 +178,7 @@ func (f *Fragment) AddSample(s *Sample, baseMediaDecodeTime uint64) {
 // AddSampleToTrack - allows for adding samples to any track
 // New trun boxes will be created if latest trun of fragment is not in this track
 // baseMediaDecodeTime will be used only for first sample in a trun
-func (f *Fragment) AddSampleToTrack(s *Sample, trackID uint32, baseMediaDecodeTime uint64) error {
+func (f *Fragment) AddSampleToTrack(s Sample, trackID uint32, baseMediaDecodeTime uint64) error {
 	var traf *TrafBox
 	for _, traf = range f.Moof.Trafs {
 		if traf.Tfhd.TrackID == trackID {

--- a/mp4/hdlr.go
+++ b/mp4/hdlr.go
@@ -37,6 +37,9 @@ func CreateHdlr(mediaOrHdlrType string) (*HdlrBox, error) {
 	case "subtitle", "subt":
 		hdlr.HandlerType = "subt"
 		hdlr.Name = "mp4ff subtitle handler"
+	case "text", "wvtt":
+		hdlr.HandlerType = "text"
+		hdlr.Name = "mp4ff text handler"
 	case "clcp":
 		hdlr.HandlerType = "subt"
 		hdlr.Name = "mp4ff closed captions handler"

--- a/mp4/initsegment.go
+++ b/mp4/initsegment.go
@@ -144,8 +144,10 @@ func CreateEmptyTrak(trackID, timeScale uint32, mediaType, language string) *Tra
 		minf.AddChild(CreateVmhd())
 	case "audio":
 		minf.AddChild(CreateSmhd())
-	case "subtitle":
+	case "subtitle", "subtitles":
 		minf.AddChild(&SthdBox{})
+	case "text", "wvtt":
+		minf.AddChild(&NmhdBox{})
 	default:
 		minf.AddChild(&NmhdBox{})
 	}

--- a/mp4/sample.go
+++ b/mp4/sample.go
@@ -11,8 +11,8 @@ type Sample struct {
 }
 
 // NewSample - create Sample with trun data
-func NewSample(flags uint32, dur uint32, size uint32, cto int32) *Sample {
-	return &Sample{
+func NewSample(flags uint32, dur uint32, size uint32, cto int32) Sample {
+	return Sample{
 		Flags: flags,
 		Dur:   dur,
 		Size:  size,

--- a/mp4/traf_test.go
+++ b/mp4/traf_test.go
@@ -17,7 +17,7 @@ func createTestTrafBox() *TrafBox {
 
 type testSamples struct {
 	name    string
-	samples []*Sample
+	samples []Sample
 }
 
 func TestTrafTrunWithoutOptimization(t *testing.T) {
@@ -25,7 +25,7 @@ func TestTrafTrunWithoutOptimization(t *testing.T) {
 	tests := []testSamples{
 		{
 			"audioSamples",
-			[]*Sample{
+			[]Sample{
 				{SyncSampleFlags, 1024, 234, 0},
 				{SyncSampleFlags, 1024, 235, 0},
 				{SyncSampleFlags, 1024, 235, 0},
@@ -33,7 +33,7 @@ func TestTrafTrunWithoutOptimization(t *testing.T) {
 		},
 		{
 			"videoWithInitialSyncSample",
-			[]*Sample{
+			[]Sample{
 				{SyncSampleFlags, 1024, 234, 0},
 				{NonSyncSampleFlags, 1024, 235, 0},
 				{NonSyncSampleFlags, 1024, 235, 0},
@@ -41,7 +41,7 @@ func TestTrafTrunWithoutOptimization(t *testing.T) {
 		},
 		{
 			"videoWithMultipleSyncSamplesAndCto",
-			[]*Sample{
+			[]Sample{
 				{SyncSampleFlags, 1024, 234, 0},
 				{NonSyncSampleFlags, 1024, 235, 2048},
 				{SyncSampleFlags, 1024, 235, -1024},
@@ -49,13 +49,13 @@ func TestTrafTrunWithoutOptimization(t *testing.T) {
 		},
 		{
 			"singleSample",
-			[]*Sample{
+			[]Sample{
 				{SyncSampleFlags, 1024, 234, 0},
 			},
 		},
 		{
 			"sameSize",
-			[]*Sample{
+			[]Sample{
 				{SyncSampleFlags, 1024, 234, 0},
 				{SyncSampleFlags, 1024, 234, 0},
 			},

--- a/mp4/trun.go
+++ b/mp4/trun.go
@@ -310,6 +310,12 @@ func (t *TrunBox) AddSample(s Sample) {
 	t.sampleCount++
 }
 
+// AddSamples - add a a slice of Sample
+func (t *TrunBox) AddSamples(s []Sample) {
+	t.Samples = append(t.Samples, s...)
+	t.sampleCount += uint32(len(s))
+}
+
 // Duration - calculated duration given defaultSampleDuration
 func (t *TrunBox) Duration(defaultSampleDuration uint32) uint64 {
 	if !t.HasSampleDuration() {

--- a/mp4/trun.go
+++ b/mp4/trun.go
@@ -269,25 +269,24 @@ func (t *TrunBox) Info(w io.Writer, specificBoxLevels, indent, indentStep string
 	return bd.err
 }
 
-// GetFullSamples - get all sample data including accumulated time and binary media
-// baseOffset is offset in mdat (normally 8)
-// baseTime is offset in track timescale (from mfhd)
-// To fill missing individual values from tfhd and trex defaults, call AddSampleDefaultValues() before this call
-func (t *TrunBox) GetFullSamples(baseOffset uint32, baseTime uint64, mdat *MdatBox) []FullSample {
+// GetFullSamples - get all sample data including accumulated time and binary media data
+// offsetInMdat is offset in mdat data (data normally starts 8 or 16 bytes after start of mdat box)
+// baseDecodeTime is decodeTime in tfdt in track timescale (timescale in mfhd)
+// To fill missing individual values from tfhd and trex defaults, call trun.AddSampleDefaultValues() before this call
+func (t *TrunBox) GetFullSamples(offsetInMdat uint32, baseDecodeTime uint64, mdat *MdatBox) []FullSample {
 	samples := make([]FullSample, 0, t.SampleCount())
 	var accDur uint64 = 0
-	offset := baseOffset
 	for _, s := range t.Samples {
-		dTime := baseTime + accDur
+		dTime := baseDecodeTime + accDur
 
 		newSample := FullSample{
 			Sample:     s,
 			DecodeTime: dTime,
-			Data:       mdat.Data[offset : offset+s.Size],
+			Data:       mdat.Data[offsetInMdat : offsetInMdat+s.Size],
 		}
 		samples = append(samples, newSample)
 		accDur += uint64(s.Dur)
-		offset += s.Size
+		offsetInMdat += s.Size
 	}
 	return samples
 }

--- a/mp4/trun.go
+++ b/mp4/trun.go
@@ -16,7 +16,7 @@ type TrunBox struct {
 	sampleCount      uint32
 	DataOffset       int32
 	firstSampleFlags uint32 // interpreted as SampleFlags
-	Samples          []*Sample
+	Samples          []Sample
 	writeOrderNr     uint32 // Used for multi trun offsets
 }
 
@@ -273,15 +273,15 @@ func (t *TrunBox) Info(w io.Writer, specificBoxLevels, indent, indentStep string
 // baseOffset is offset in mdat (normally 8)
 // baseTime is offset in track timescale (from mfhd)
 // To fill missing individual values from tfhd and trex defaults, call AddSampleDefaultValues() before this call
-func (t *TrunBox) GetFullSamples(baseOffset uint32, baseTime uint64, mdat *MdatBox) []*FullSample {
-	samples := make([]*FullSample, 0, t.SampleCount())
+func (t *TrunBox) GetFullSamples(baseOffset uint32, baseTime uint64, mdat *MdatBox) []FullSample {
+	samples := make([]FullSample, 0, t.SampleCount())
 	var accDur uint64 = 0
 	offset := baseOffset
 	for _, s := range t.Samples {
 		dTime := baseTime + accDur
 
-		newSample := &FullSample{
-			Sample:     *s,
+		newSample := FullSample{
+			Sample:     s,
 			DecodeTime: dTime,
 			Data:       mdat.Data[offset : offset+s.Size],
 		}
@@ -294,18 +294,18 @@ func (t *TrunBox) GetFullSamples(baseOffset uint32, baseTime uint64, mdat *MdatB
 
 // GetSamples - get all trun sample data
 // To fill missing individual values from thd and trex defaults, call AddSampleDefaultValues() before this call
-func (t *TrunBox) GetSamples() []*Sample {
+func (t *TrunBox) GetSamples() []Sample {
 	return t.Samples
 }
 
 // AddFullSample - add Sample part of FullSample
 func (t *TrunBox) AddFullSample(s *FullSample) {
-	t.Samples = append(t.Samples, &s.Sample)
+	t.Samples = append(t.Samples, s.Sample)
 	t.sampleCount++
 }
 
 // AddSample - add a Sample
-func (t *TrunBox) AddSample(s *Sample) {
+func (t *TrunBox) AddSample(s Sample) {
 	t.Samples = append(t.Samples, s)
 	t.sampleCount++
 }


### PR DESCRIPTION
Change of API in GetSamples and GetFullSamples to return slices of samples instead of slices of pointers.
This means some more data copying, but less garbage collection.

Added new methods to add multiple samples AddSamples.

Improved Makefile: run `make all` and it will run tests, build commands, and run golangci-lint.

Added new init segment creation for `text/wvtt`.