### PR TITLE
Version 0.25.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,15 @@ All child boxes of container box such as `MoovBox` are listed in the `Children` 
 most prominent child boxes have direct links with names which makes it possible to write a path such
 as
 
+```go
     fragment.Moof.Traf.Trun
+```
 
 to access the (only) `trun` box in a fragment with only one `traf` box, or
 
+```go
     fragment.Moof.Trafs[1].Trun[1]
+```
 
 to get the second `trun` of the second `traf` box (provided that they exist).
 
@@ -54,9 +58,11 @@ A typical use case is to a fragment consisting of an init segment followed by a 
 The first step is to create the init segment. This is done in three steps as can be seen in
 `examples/initcreator`:
 
-1. `init := mp4.CreateEmptyInit()`
-2. `init.AddEmptyTrack(timescale, mediatype, language)`
-3. `init.Moov.Trak.SetHEVCDescriptor("hvc1", vpsNALUs, spsNALUs, ppsNALUs)`
+```go
+    init := mp4.CreateEmptyInit()
+    init.AddEmptyTrack(timescale, mediatype, language)
+    init.Moov.Trak.SetHEVCDescriptor("hvc1", vpsNALUs, spsNALUs, ppsNALUs)
+```
 
 Here the third step fills in codec-specific parameters into the sample descriptor of the single track.
 Multiple tracks are also available via the slice attribute `Traks` instead of `Trak`.
@@ -72,6 +78,7 @@ fragment in each segment. Example code for this can be found in `examples/segmen
 One way of creating a media segment is to first create a slice of `FullSample` with the data needed.
 The definition of `mp4.FullSample` is
 
+```go
 	mp4.FullSample{
 		Sample: mp4.Sample{
 	        Flags uint32 // Flag sync sample etc
@@ -82,6 +89,7 @@ The definition of `mp4.FullSample` is
 	    DecodeTime uint64 // Absolute decode time (offset + accumulated sample Dur)
 	    Data       []byte // Sample data
 	}
+```
 
 The `mp4.Sample` part is what will be written into the `trun` box.
 `DecodeTime` is the media timeline accumulated time.
@@ -90,16 +98,20 @@ be set as the `BaseMediaDecodeTime` in the `tfdt` box.
 
 Once a number of such full samples are available, they can be added to a media segment like
 
+```go
 	seg := mp4.NewMediaSegment()
 	frag := mp4.CreateFragment(uint32(segNr), mp4.DefaultTrakID)
 	seg.AddFragment(frag)
 	for _, sample := range samples {
 		frag.AddFullSample(sample)
 	}
+```
 
 This segment can finally be output to a `w io.Writer` as
 
+```go
     err := seg.Encode(w)
+```
 
 For multi-track segments, the code is a bit more involved. Please have a look at `examples/segmenter`
 to see how it is done. One can also write the media data part of the samples
@@ -115,17 +127,23 @@ to later.
 
 For decoding, this is supported by running `mp4.DecodeFile()` in lazy mode as
 
+```go
     parsedMp4, err = mp4.DecodeFile(ifd, mp4.WithDecodeMode(mp4.DecModeLazyMdat))
+```
 
 In this case, the media data of the `mdat` box will not be read, but only its size is being set.
 To read or copy the actual data corresponding to a sample, one must calculate the
 corresponding byte range and either call
 
+```go
      func (m *MdatBox) ReadData(start, size int64, rs io.ReadSeeker) ([]byte, error)
+```
 
 or
 
+```
      func (m *MdatBox) CopyData(start, size int64, rs io.ReadSeeker, w io.Writer) (nrWritten int64, err error)
+```
 
 Example code for this, including lazy writing of `mdat`, can be found in `examples/segmenter`
 with the `lazy` mode set.

--- a/Versions.md
+++ b/Versions.md
@@ -2,6 +2,7 @@
 
 | Version | Highlight |
 | ------  | --------- |
+| 0.25.0 | Support sample intervals. Control first sample flags. Create subtitle init segments. Minor improvements and fixes |
 | 0.24.0 | api-change: DecodeFile lazy mode. Enhanced segmenter example with lazy read/write. |
 | 0.23.1 | fix: segment encode mode without optimization
 | 0.23.0 | api-change: encode mode and optimization options |

--- a/mp4/README.md
+++ b/mp4/README.md
@@ -1,10 +1,10 @@
 # Parsing and generation of MP4 (isobmff) boxes.
 
 ## Background
-The Box interfaces and some code in this directory is from the project https://github.com/jfbus/mp4. It has been vastly enhanced and the focus has changed from progessive mp4 files to segmented files.
+The Box interfaces and some code in this directory is from the project https://github.com/jfbus/mp4. It has been vastly enhanced and the focus has changed from progressive mp4 files to segmented files.
 
 ## Overall structure
-Most boxes have their own file named after the box, but in some cases, there may be multiple boxes that have the same content, and the code is then having a generic name like visualsampleentry.go.
+Most boxes have their own file named after the box, but in some cases, there may be multiple boxes that have the same content, and the code is then having a generic name like `visualsampleentry.go`.
 
 
 The Box interface is specified in `box.go`. It does not contain decode (parsing) methods which have distinct names for each box type
@@ -16,23 +16,28 @@ To implement a new box `fooo`, the following is needed.
 
 Create a file `fooo.go` and create a struct type `FoooBox`.
 
-Fooo should then implement the Box interface methods:
+FoooBox should then implement the Box interface methods:
 
+```go
      Type()
      Size()
      Encode()
      Info()
+```
 
-but also its own decode method `DecodeFooo`, and register that method in the `decoders` map in `box.go`. For a simple example, look at the `prft` box in `prft.go`.
+but also its own decode method `DecodeFooo`, and register that method in the `decoders` map in `box.go`.
+For a simple example, look at the `prft` box in `prft.go`.
 
-A test file `fooo_test.go` should have a test using the method `boxDiffAfterEncodeAndDecode`to check that the box information is equal after
-encoding and decoding.
+A test file `fooo_test.go` should have a test using the method `boxDiffAfterEncodeAndDecode` to check that
+the box information is equal after encoding and decoding.
 
 Container boxes like `moof`, have a list of all their children called `Children`,
 but also direct pointers to the children with appropriate names, like `Mfhd`
-and `Traf`. This makes it easy to chain box paths to reach an element like a TfhdBox as
+and `Traf`. This makes it easy to chain box paths to reach an element like a `TfhdBox` as
 
+```go
     file.Moof.Traf.Tfhd
+```
 
 When there may be multiple children with the same name, there may be both a
 slice `Trafs` with all boxes and `Traf` that points to the first.
@@ -44,9 +49,9 @@ To handle media sample data there are two structures:
 
 A MediaSegment can be fragmented into multiple fragments by the method
 
+```go
     func (s *MediaSegment) Fragmentify(timescale uint64, trex *TrexBox, duration uint32) ([]*Fragment, error)
-
-
+```
 
 ## License
 See [LICENSE.md](LICENSE.md)

--- a/mp4/version.go
+++ b/mp4/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	commitVersion string = "v0.24.0+dev" // May be updated using build flags
-	commitDate    string                 // commitDate in Epoch seconds (may be overridden using build flags)
+	commitVersion string = "v0.25.0" // May be updated using build flags
+	commitDate    string             // commitDate in Epoch seconds (may be overridden using build flags)
 )
 
 // GetVersion - get version and also commitHash and commitDate if inserted via Makefile


### PR DESCRIPTION
* Size() methods to InitSegment, Fragment and MediaSegment
* Improvements to ctts and stts boxes
* Slices of samples and fullsamples 
* Create init segments for wvtt and stpp
* Changed sample slices to remove pointers
* SampleIntervals for more efficient transformation of segments
* Spell out compositionTimeOffset instead of cto
* More efficient code to check for AVC and HEVC parameter sets