### PR TITLE
feat: SEI parsing for AVC and new SEI option in mp4ff-nallister

### DIFF
--- a/avc/sei.go
+++ b/avc/sei.go
@@ -1,0 +1,289 @@
+package avc
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+
+	"github.com/edgeware/mp4ff/bits"
+)
+
+const (
+	SEIPicTimingType    = 1
+	SEIRegisteredType   = 4
+	SEIUnregisteredType = 5
+)
+
+// SEI - Supplementary Enhancement Information as defined in ISO/IEC 14496-10
+// High level syntax in Section 7.3.2.3
+// The actual types are listed in Annex D
+type SEI struct {
+	SEIMessages []SEIMessage
+}
+
+// SEIMessage is common part of any SEI message
+type SEIMessage interface {
+	Type() uint
+	Size() uint
+	String() string
+	Payload() []byte
+}
+
+// DecodeSEIMessage decodes an SEIMessage
+func DecodeSEIMessage(sd *SEIData) (SEIMessage, error) {
+	switch sd.Type() {
+	case 4:
+		return DecodeUserDataRegisteredSEI(sd)
+	case 5:
+		return DecodeUserDataUnregisteredSEI(sd)
+	default:
+		return sd, nil
+	}
+}
+
+// SEIData - raw parsed SEI message with rbsp data
+type SEIData struct {
+	payloadType uint
+	payload     []byte
+}
+
+// Type - SEI payload type
+func (s *SEIData) Type() uint {
+	return s.payloadType
+}
+
+// Payload - SEI raw rbsp payload
+func (s *SEIData) Payload() []byte {
+	return s.payload
+}
+
+// String - print up to 100 bytes of payload
+func (s *SEIData) String() string {
+	return fmt.Sprintf("SEI type %d, size=%d, %q", s.Type(), s.Size(), hex.EncodeToString(s.payload))
+}
+
+// Size - size in bytes of raw SEI message rbsp payload
+func (s *SEIData) Size() uint {
+	return uint(len(s.payload))
+}
+
+// ExtractSEIData - parse ebsp and return SEIData in rbsp format
+func ExtractSEIData(r io.ReadSeeker) (seiData []SEIData, err error) {
+	ar := bits.NewAccErrEBSPReader(r)
+	for {
+		payloadType := uint(0)
+		for {
+			nextByte := ar.Read(8)
+			payloadType += uint(nextByte)
+			if nextByte != 0xff {
+				break
+			}
+		}
+		payloadSize := uint32(0)
+		for {
+			nextByte := ar.Read(8)
+			payloadSize += uint32(nextByte)
+			if nextByte != 0xff {
+				break
+			}
+		}
+		payload := ar.ReadBytes(int(payloadSize))
+		if ar.AccError() != nil {
+			return nil, ar.AccError()
+		}
+
+		seiData = append(seiData, SEIData{payloadType, payload})
+		if ar.AccError() != nil {
+			return nil, ar.AccError()
+		}
+		// Break loop if no more rbsp data (end of sei messages)
+		more, err := ar.MoreRbspData()
+		if err != nil {
+			return nil, err
+		}
+		if ar.AccError() != nil {
+			return nil, ar.AccError()
+		}
+		if !more {
+			break
+		}
+	}
+	return seiData, nil
+}
+
+// DecodeUserDataRegisteredSEI - decode a SEI message of byte 4
+func DecodeUserDataRegisteredSEI(sd *SEIData) (SEIMessage, error) {
+	itutData := ITUData{
+		CountryCode:      sd.payload[0],
+		ProviderCode:     binary.BigEndian.Uint16(sd.payload[1:3]),
+		UserIdentifier:   binary.BigEndian.Uint32(sd.payload[3:7]),
+		UserDataTypeCode: sd.payload[7],
+	}
+	if itutData.IsCEA608() {
+		return NewCEA608sei(sd)
+	}
+	return NewRegisteredSEI(sd, itutData), nil
+}
+
+// ITUData - first 8 bytes of payload for CEA-608 in type 4 (User data registered by ITU-T Rec T 35)
+type ITUData struct {
+	CountryCode      byte
+	UserDataTypeCode byte
+	ProviderCode     uint16
+	UserIdentifier   uint32
+}
+
+// IsCEA608 - check if ITU-T data corresponds to CEA-608
+func (i ITUData) IsCEA608() bool {
+	return (i.CountryCode == 0xb5 &&
+		i.ProviderCode == 0x31 &&
+		i.UserIdentifier == 0x47413934 &&
+		i.UserDataTypeCode == 0x3)
+}
+
+// RegisteredSEI - user_data_registered_itu_t_t35 SEI message
+type RegisteredSEI struct {
+	payload  []byte
+	ITUTData ITUData
+}
+
+// NewRegisteredSEI - create an ITU-T registered SEI message (type 4)
+func NewRegisteredSEI(sd *SEIData, ituData ITUData) *RegisteredSEI {
+	return &RegisteredSEI{
+		payload:  sd.payload,
+		ITUTData: ituData,
+	}
+}
+
+// Type - SEI payload type
+func (s *RegisteredSEI) Type() uint {
+	return SEIRegisteredType
+}
+
+// Size - size in bytes of raw SEI message rbsp payload
+func (s *RegisteredSEI) Size() uint {
+	return uint(len(s.payload))
+}
+
+func (s *RegisteredSEI) String() string {
+	return fmt.Sprintf("SEI type %d, size=%d, %v", s.Type(), s.Size(), s.ITUTData)
+}
+
+// Payload - SEI raw rbsp payload
+func (s *RegisteredSEI) Payload() []byte {
+	return s.payload
+}
+
+// NewCEA608sei - new CEA 608 SEI message including parsing of CEA-608 fields
+func NewCEA608sei(sd *SEIData) (*CEA608sei, error) {
+	field1, field2, err := parseCEA608(sd.payload[8:])
+	if err != nil {
+		return nil, err
+	}
+	return &CEA608sei{
+		payload: sd.payload,
+		Field1:  field1,
+		Field2:  field2,
+	}, nil
+}
+
+// CEA608sei message according to
+type CEA608sei struct {
+	payload []byte // full raw payload
+	Field1  []byte
+	Field2  []byte
+}
+
+// Type - SEI payload type
+func (s *CEA608sei) Type() uint {
+	return SEIRegisteredType
+}
+
+// Size - size in bytes of raw SEI message rbsp payload
+func (s *CEA608sei) Size() uint {
+	return uint(len(s.payload))
+}
+
+func (s *CEA608sei) String() string {
+	return fmt.Sprintf("SEI type %d CEA-608, size=%d, field1: %q, field2: %q", s.Type(), s.Size(),
+		hex.EncodeToString(s.Field1), hex.EncodeToString(s.Field2))
+}
+
+// Payload - SEI raw rbsp payload
+func (s *CEA608sei) Payload() []byte {
+	return s.payload
+}
+
+func parseCEA608(payload []byte) ([]byte, []byte, error) {
+	pos := 0
+	ccCount := payload[pos] & 0x1f
+	pos += 2 // Advance 1 and skip reserved byte
+	var field1 []byte
+	var field2 []byte
+
+	for i := byte(0); i < ccCount; i++ {
+		if len(payload) < pos+3 {
+			return nil, nil, fmt.Errorf("Not enough data for CEA-708 parsing")
+		}
+		b := payload[pos]
+		ccValid := b & 0x4
+		ccType := b & 0x3
+		pos++
+		ccData1 := payload[pos] // Keep parity bit
+		pos++
+		ccData2 := payload[pos] // Keep parity bit
+		pos++
+		if ccValid != 0 && ((ccData1&0x7f)+(ccData2&0x7f) != 0) { //Check validity and non-empty data
+			if ccType == 0 {
+				field1 = append(field1, ccData1)
+				field1 = append(field1, ccData2)
+			} else if ccType == 1 {
+				field2 = append(field2, ccData1)
+				field2 = append(field2, ccData2)
+			}
+		}
+	}
+	return field1, field2, nil
+}
+
+// UnregisteredSEI - SEI message of type 5
+type UnregisteredSEI struct {
+	UUID    []byte
+	payload []byte
+}
+
+// Type - SEI payload type
+func (s *UnregisteredSEI) Type() uint {
+	return SEIUnregisteredType
+}
+
+// Size - size in bytes of raw SEI message rbsp payload
+func (s *UnregisteredSEI) Size() uint {
+	return uint(len(s.payload))
+}
+
+func (s *UnregisteredSEI) String() string {
+	payloadAfterUUID := string(s.payload[16:])
+	return fmt.Sprintf("SEI type %d, size=%d, uuid=%q, payload=%q",
+		s.Type(), s.Size(), hex.EncodeToString(s.UUID), payloadAfterUUID)
+}
+
+// Payload - SEI raw rbsp payload
+func (s *UnregisteredSEI) Payload() []byte {
+	return s.payload
+}
+
+// DecodeUserDataUnregisteredSEI - Decode an unregistered SEI message (type 5)
+func DecodeUserDataUnregisteredSEI(sd *SEIData) (SEIMessage, error) {
+	uuid := sd.payload[:16]
+	return NewUnregisteredSEI(sd, uuid), nil
+}
+
+// NewUnregisteredSEI - Create an unregistered SEI message (type 5)
+func NewUnregisteredSEI(sd *SEIData, uuid []byte) *UnregisteredSEI {
+	return &UnregisteredSEI{
+		UUID:    uuid,
+		payload: sd.payload,
+	}
+}

--- a/avc/sei_test.go
+++ b/avc/sei_test.go
@@ -1,0 +1,48 @@
+package avc
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"testing"
+)
+
+const (
+	sei0Hex = "060007810f1c0050744080"
+	sei4Hex = "660434b500314741393403cefffc9420fc94aefc9162fce56efc67bafc91b9fcb0b0fcbab0fcb0bafcb031fcbab0fcb080fc942cfc942f80"
+)
+
+func TestParseSEI(t *testing.T) {
+
+	testCases := []struct {
+		name         string
+		naluHex      string
+		wantedType   uint
+		wantedString string
+	}{
+		{"Type 0", sei0Hex, 0, `SEI type 0, size=7, "810f1c00507440"`},
+		{"Type 4", sei4Hex, 4, `SEI type 4 CEA-608, size=28, field1: "942094ae9162e56e67ba91b9b0b0bab0b0bab031bab0b080942c942f", field2: ""`},
+	}
+
+	for _, tc := range testCases {
+		seiNALU, _ := hex.DecodeString(tc.naluHex)
+
+		rs := bytes.NewReader(seiNALU[1:]) // Drop AVC header
+
+		seis, err := ExtractSEIData(rs)
+		if err != nil {
+			t.Error(err)
+		}
+		if len(seis) != 1 {
+			t.Errorf("%s: Not 1 but %d sei messages found", tc.name, len(seis))
+		}
+		seiMessage, err := DecodeSEIMessage(&seis[0])
+		if err != nil {
+			t.Error(err)
+		}
+		if seiMessage.Type() != tc.wantedType {
+			t.Errorf("%s: got SEI type %d instead of %d", tc.name, seiMessage.Type(), tc.wantedType)
+		}
+		fmt.Println(seiMessage)
+	}
+}

--- a/avc/sps.go
+++ b/avc/sps.go
@@ -348,6 +348,23 @@ func ParseSPSNALUnit(data []byte, parseVUIBeyondAspectRatio bool) (*SPS, error) 
 	return sps, nil
 }
 
+// CpbDbpDelaysPresent signals if Cpb and Dbp can be found in Picture Timing SEI
+func (s *SPS) CpbDpbDelaysPresent() bool {
+	if s.VUI == nil {
+		return false
+	}
+	return (s.VUI.NalHrdParametersPresentFlag ||
+		s.VUI.VclHrdParametersPresentFlag)
+}
+
+// PicStructPresent signals if pic struct can be found in Picture Timing SEI
+func (s *SPS) PicStructPresent() bool {
+	if s.VUI == nil {
+		return false
+	}
+	return s.VUI.PicStructPresentFlag
+}
+
 // parseVUI - parse VUI (Visual Usability Information)
 // if parseVUIBeyondAspectRatio is false, stop after AspectRatio has been parsed
 func parseVUI(reader *bits.EBSPReader, parseVUIBeyondAspectRatio bool) (*VUIParameters, error) {

--- a/bits/aeebspreader.go
+++ b/bits/aeebspreader.go
@@ -81,6 +81,22 @@ func (r *AccErrEBSPReader) Read(n int) uint {
 	return v
 }
 
+// Read - read n bytes and return nil if (previous) error or if n bytes not available
+func (r *AccErrEBSPReader) ReadBytes(n int) []byte {
+	if r.err != nil {
+		return nil
+	}
+	payload := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b := byte(r.Read(8))
+		payload[i] = b
+	}
+	if r.err != nil {
+		return nil
+	}
+	return payload
+}
+
 // ReadFlag - read 1 bit into bool. Return false if not possible
 func (r *AccErrEBSPReader) ReadFlag() bool {
 	return r.Read(1) == 1

--- a/bits/aereader.go
+++ b/bits/aereader.go
@@ -61,3 +61,14 @@ func (r *AccErrReader) ReadFlag() bool {
 	}
 	return bit == 1
 }
+
+// ReadFlag - Read i(v) which is 2-complement of n bits
+func (r *AccErrReader) ReadVInt(n int) int {
+	uval := r.Read(n)
+	var ival int
+
+	if uval >= 1<<(n/2) {
+		ival = int(uval) - (1 << n)
+	}
+	return ival
+}

--- a/bits/aereader_test.go
+++ b/bits/aereader_test.go
@@ -31,7 +31,7 @@ func TestAccErrReader(t *testing.T) {
 	}
 	err := reader.AccError()
 	if err != nil {
-		t.Errorf("Got accumulated error: %w", err)
+		t.Errorf("Got accumulated error: %s", err.Error())
 	}
 }
 


### PR DESCRIPTION
Add support for parsing and interpreting SEI NAL units for AVC (but may work for HEVC as well).
There is general SEI parsing to just get the type and payload, and specific parsing
for type 4 (registered) and 5 (unregistered).
For registered, CEA-708 is detected and CEA-608 caption data is extracted.

Support for viewing this information is added to `mp4ff-nallister` with a new `-sei` option.