### PR TITLE
New tool: mp4ff-crop

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,11 @@ Some useful command line tools are available in `cmd`.
 2. `mp4ff-pslister` extracts and displays SPS and PPS for AVC in a mp4 file. Partial information is printed for HEVC.
 3. `mp4ff-nallister` lists NALUs and picture types for video in progressive or fragmented file
 4. `mp4ff-wvttlister` lists details of wvtt (WebVTT in ISOBMFF) samples
+5. `mp4ff-crop` shortens a progressive mp4 file to a specified duration
 
-You can install these tools by going to their respective directory and run `go install .`.
+You can install these tools by going to their respective directory and run `go install .` or directly from the repo with
+
+    go install github.com/edgeware/mp4ff/cmd/mp4ff-info@latest
 
 ## Example code
 

--- a/cmd/mp4ff-crop/byteranges.go
+++ b/cmd/mp4ff-crop/byteranges.go
@@ -1,0 +1,30 @@
+package main
+
+type byteRange struct {
+	start uint64
+	end   uint64 // Included
+}
+
+type byteRanges struct {
+	ranges []byteRange
+}
+
+func createByteRanges() *byteRanges {
+	return &byteRanges{}
+}
+
+func (b *byteRanges) addRange(start, end uint64) {
+	if len(b.ranges) == 0 || b.ranges[len(b.ranges)-1].end+1 != start {
+		b.ranges = append(b.ranges, byteRange{start, end})
+		return
+	}
+	b.ranges[len(b.ranges)-1].end = end
+}
+
+func (b *byteRanges) size() uint64 {
+	var totSize uint64 = 0
+	for _, br := range b.ranges {
+		totSize += br.end - br.start + 1
+	}
+	return uint64(totSize)
+}

--- a/cmd/mp4ff-crop/crop_test.go
+++ b/cmd/mp4ff-crop/crop_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/edgeware/mp4ff/mp4"
+)
+
+// TestCroppedFileDuration - simple test to check that cropped file has right duration
+// In general, this duration will not be exactly the same as the one asked for.
+func TestCroppedFileDuration(t *testing.T) {
+	testFile := "../../mp4/testdata/prog_8s.mp4"
+	cropDur := 2000
+
+	ifh, err := os.Open(testFile)
+	if err != nil {
+		t.Error(err)
+	}
+	defer ifh.Close()
+	parsedMp4, err := mp4.DecodeFile(ifh, mp4.WithDecodeMode(mp4.DecModeLazyMdat))
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf := bytes.Buffer{}
+
+	err = cropMP4(parsedMp4, cropDur, &buf, ifh)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	decCropped, err := mp4.DecodeFile(&buf)
+	if err != nil {
+		t.Error(err)
+	}
+	moovDur := decCropped.Moov.Mvhd.Duration
+	moovTimescale := decCropped.Moov.Mvhd.Timescale
+	if uint64(cropDur)*uint64(moovTimescale) != moovDur*1000 {
+		t.Errorf("got %d/%dms instead of %dms", moovDur, moovTimescale, cropDur)
+	}
+}

--- a/cmd/mp4ff-crop/main.go
+++ b/cmd/mp4ff-crop/main.go
@@ -1,0 +1,360 @@
+/*
+mp4ff-crop crops a (progressive) mp4 file to just before a sync frame after specified number of milliseconds.
+The intension is that the structure of the file shall be left intact except for cropping of samples and
+moving mdat to the end of the file, if not already there.
+*/
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/edgeware/mp4ff/mp4"
+)
+
+var usg = `Usage of mp4ff-crop:
+
+mp4ff-crop crops a (progressive) mp4 file to just before a sync frame after specified number of milliseconds.
+The intension is that the structure of the file shall be left intact except for cropping of samples and
+moving mdat to the end of the file, if not already there.
+`
+
+var usage = func() {
+	parts := strings.Split(os.Args[0], "/")
+	name := parts[len(parts)-1]
+	fmt.Fprintln(os.Stderr, usg)
+	fmt.Fprintf(os.Stderr, "%s [-d duration] <inFile> <outFile>\n", name)
+	flag.PrintDefaults()
+}
+
+func main() {
+	durationMS := flag.Int("d", 0, "Duration in milliseconds")
+	version := flag.Bool("version", false, "Get mp4ff version")
+	flag.Parse()
+
+	if *version {
+		fmt.Printf("mp4ff-crop %s\n", mp4.GetVersion())
+		os.Exit(0)
+	}
+
+	if *durationMS <= 0 {
+		usage()
+		os.Exit(1)
+	}
+
+	var inFilePath = flag.Arg(0)
+	if inFilePath == "" {
+		usage()
+		os.Exit(1)
+	}
+
+	var outFilePath = flag.Arg(1)
+	if outFilePath == "" {
+		usage()
+		os.Exit(1)
+	}
+
+	ifh, err := os.Open(inFilePath)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer ifh.Close()
+	parsedMp4, err := mp4.DecodeFile(ifh, mp4.WithDecodeMode(mp4.DecModeLazyMdat))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ofh, err := os.Create(outFilePath)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer ofh.Close()
+
+	err = cropMP4(parsedMp4, *durationMS, ofh, ifh)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+}
+
+func cropMP4(inMP4 *mp4.File, durationMS int, w io.Writer, ifh io.ReadSeeker) error {
+	if inMP4.IsFragmented() {
+		return fmt.Errorf("only progressive files are supported")
+	}
+	inMoov := inMP4.Moov
+	inMoovDur := float64(inMoov.Mvhd.Duration) / float64(inMoov.Mvhd.Timescale)
+	fmt.Printf("input moov duration = %.3fs\n", inMoovDur)
+
+	endTime, endTimescale, err := findEndTime(inMoov, durationMS)
+	if err != nil {
+		return err
+	}
+
+	err = cropToTime(inMP4, endTime, endTimescale, w, ifh)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("wrote output with endTime=%dms\n", (endTime*1000)/endTimescale)
+	return nil
+
+}
+
+// findEndTime - find closest video sync frame, or audio frame if no video
+func findEndTime(moov *mp4.MoovBox, durationMS int) (endTime, endTimescale uint64, err error) {
+	var syncTrak *mp4.TrakBox
+	for _, trak := range moov.Traks {
+		if trak.Mdia.Hdlr.HandlerType == "vide" {
+			syncTrak = trak
+			break
+		}
+	}
+	if syncTrak == nil {
+		for _, trak := range moov.Traks {
+			if trak.Mdia.Hdlr.HandlerType == "soun" {
+				syncTrak = trak
+				fmt.Printf("Uses audio track %d for endtime\n", trak.Tkhd.TrackID)
+				break
+			}
+		}
+	}
+	if syncTrak == nil {
+		return 0, 0, fmt.Errorf("did not find any video or audio track")
+	}
+
+	//trakDur := float64(trak.Tkhd.Duration) / float64(moov.Mvhd.Timescale)
+	//fmt.Printf("video trak %d duration = %.3fs\n", trak.Tkhd.TrackID, trakDur)
+	endTimescale = uint64(syncTrak.Mdia.Mdhd.Timescale)
+	endTime = uint64(durationMS) * endTimescale / 1000
+
+	stbl := syncTrak.Mdia.Minf.Stbl
+	stts := stbl.Stts // TimeToSampleBox
+	lastSampleNr, err := stts.GetSampleNrAtTime(endTime)
+	if err != nil {
+		return 0, 0, err
+	}
+	stss := stbl.Stss
+	if stss != nil {
+		foundSyncFrame := false
+		for sampleNr := lastSampleNr; sampleNr <= stss.SampleNumber[len(stss.SampleNumber)-1]; sampleNr++ {
+			if stss.IsSyncSample(sampleNr) {
+				lastSampleNr = sampleNr - 1
+				foundSyncFrame = true
+				break
+			}
+		}
+		if !foundSyncFrame {
+			return 0, 0, fmt.Errorf("did not find any syncframe at or after time")
+		}
+	}
+	lastTime, lastDur := stts.GetDecodeTime(lastSampleNr)
+	endTime = lastTime + uint64(lastDur)
+
+	return endTime, endTimescale, nil
+}
+
+func cropToTime(inMP4 *mp4.File, endTime, endTimescale uint64, w io.Writer, ifh io.ReadSeeker) error {
+	traks := inMP4.Moov.Traks
+	tos, err := findTrakEnds(traks, endTime, endTimescale)
+	if err != nil {
+		return err
+	}
+	byteRanges := createByteRanges()
+	firstOffset, err := fillTrakOutsAndByteRanges(traks, tos, byteRanges)
+	if err != nil {
+		return err
+	}
+
+	cropStblChildren(traks, tos)
+	updateChunkOffsets(inMP4, firstOffset)
+
+	err = writeUptoMdat(inMP4, endTime, endTimescale, w)
+	if err != nil {
+		return err
+	}
+
+	err = writeMdat(byteRanges, inMP4.Mdat, w, ifh)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type trakOut struct {
+	lastSampleNr  uint32
+	endTime       uint64
+	lastChunk     mp4.Chunk
+	nextInChunkNr uint32
+	chunkOffsets  []uint64
+}
+
+// findTrakEnds - find where traks end in form of last chunk, lastSampleNr and endTime
+func findTrakEnds(traks []*mp4.TrakBox, endTime, endTimescale uint64) (map[uint32]*trakOut, error) {
+	tos := make(map[uint32]*trakOut, len(traks))
+	for _, trak := range traks {
+		trackID := trak.Tkhd.TrackID
+		stbl := trak.Mdia.Minf.Stbl
+		tos[trackID] = &trakOut{
+			nextInChunkNr: 1,
+		}
+		to := tos[trackID]
+		trackTimeScale := trak.Mdia.Mdhd.Timescale
+		trackEndTime := endTime
+		if trackTimeScale != uint32(endTimescale) {
+			trackEndTime = endTime * uint64(trackTimeScale) / endTimescale
+		}
+		stts := stbl.Stts
+		endSampleNr, err := stts.GetSampleNrAtTime(trackEndTime)
+		if err != nil {
+			return nil, err
+		}
+		endSampleNr--
+		to.lastSampleNr = endSampleNr
+		decTime, dur := stts.GetDecodeTime(endSampleNr)
+		trackEndTime = decTime + uint64(dur)
+		tos[trackID].endTime = trackEndTime
+		stsc := stbl.Stsc
+		chunkNr, _, err := stsc.ChunkNrFromSampleNr(int(endSampleNr))
+		if err != nil {
+			return nil, err
+		}
+		chunk := stsc.GetChunk(uint32(chunkNr))
+		to.lastChunk = chunk
+	}
+	return tos, nil
+}
+
+func fillTrakOutsAndByteRanges(traks []*mp4.TrakBox, tos map[uint32]*trakOut, byteRanges *byteRanges) (firstOffset uint64, err error) {
+	var currentOutOffset uint64
+	var minChunkOffset uint64
+	for {
+		var trakIDMin uint32
+		var stblMin *mp4.StblBox
+		minChunkOffset = 1 << 62
+		for _, trak := range traks {
+			trakID := trak.Tkhd.TrackID
+			stbl := trak.Mdia.Minf.Stbl
+			to := tos[trakID]
+			nextChunkNr := int(to.nextInChunkNr)
+			if nextChunkNr > int(to.lastChunk.ChunkNr) {
+				continue
+			}
+			var chunkOffset uint64
+			var err error
+			if stbl.Stco != nil {
+				chunkOffset, err = stbl.Stco.GetOffset(nextChunkNr)
+			} else {
+				chunkOffset, err = stbl.Co64.GetOffset(nextChunkNr)
+			}
+			if err != nil {
+				return 0, err
+			}
+			if chunkOffset < minChunkOffset {
+				minChunkOffset = chunkOffset
+				trakIDMin = trakID
+				stblMin = stbl
+			}
+		}
+		if trakIDMin == 0 {
+			break //Done
+		}
+		if firstOffset == 0 {
+			firstOffset = minChunkOffset
+			currentOutOffset = firstOffset
+		}
+		to := tos[trakIDMin]
+		chunk := stblMin.Stsc.GetChunk(to.nextInChunkNr)
+		lastSampleInChunk := chunk.StartSampleNr + chunk.NrSamples - 1
+		sampleNrStart := chunk.StartSampleNr
+		sampleNrEnd := minUint32(lastSampleInChunk, to.lastSampleNr)
+		inOffset := minChunkOffset
+		outChunkSize, _ := stblMin.Stsz.GetTotalSampleSize(sampleNrStart, sampleNrEnd)
+		byteRanges.addRange(inOffset, inOffset+outChunkSize-1)
+		to.chunkOffsets = append(to.chunkOffsets, currentOutOffset)
+		currentOutOffset += outChunkSize
+		to.nextInChunkNr++
+	}
+	return firstOffset, nil
+}
+
+// updateChunkOffsets - calculate new moov size, and update stco/co64 (chunk offsets)
+func updateChunkOffsets(inMP4 *mp4.File, firstOffset uint64) {
+	var sizeWithoutMdat uint64 = 0
+	for _, box := range inMP4.Children {
+		if box.Type() != "mdat" {
+			sizeWithoutMdat += box.Size()
+		}
+	}
+	mdatStart := sizeWithoutMdat
+	mdatPayloadStart := mdatStart + 8
+	deltaOffset := int64(mdatPayloadStart) - int64(firstOffset)
+	for _, trak := range inMP4.Moov.Traks {
+		stco := trak.Mdia.Minf.Stbl.Stco
+		if stco != nil {
+			for i := range stco.ChunkOffset {
+				stco.ChunkOffset[i] = uint32(int64(stco.ChunkOffset[i]) + deltaOffset)
+			}
+		} else {
+			co64 := trak.Mdia.Minf.Stbl.Co64
+			for i := range co64.ChunkOffset {
+				co64.ChunkOffset[i] = uint64(int64(co64.ChunkOffset[i]) + deltaOffset)
+			}
+		}
+	}
+}
+
+func writeUptoMdat(inMP4 *mp4.File, endTime, endTimescale uint64, w io.Writer) error {
+	pos := uint64(0)
+	mvhd := inMP4.Moov.Mvhd
+	duration := endTime * uint64(mvhd.Timescale) / endTimescale
+	mvhd.Duration = duration
+	for _, trak := range inMP4.Moov.Traks {
+		trak.Tkhd.Duration = duration
+	}
+	for _, box := range inMP4.Children {
+		if box.Type() != "mdat" {
+			pos += box.Size()
+			err := box.Encode(w)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func writeMdat(byteRanges *byteRanges, mdatIn *mp4.MdatBox, w io.Writer, ifh io.ReadSeeker) error {
+	// write mdat header
+	mdatPayloadSize := byteRanges.size()
+	if mdatPayloadSize+8 >= 1<<32 {
+		return fmt.Errorf("too big mdat size for 32 bits: %d", mdatPayloadSize)
+	}
+	err := mp4.EncodeHeaderWithSize("mdat", mdatPayloadSize+8, false, w)
+	if err != nil {
+		return err
+	}
+	// write mdat body
+	nrBytesWritten := int64(0)
+	for _, br := range byteRanges.ranges {
+		n, err := mdatIn.CopyData(int64(br.start), int64(br.end-br.start+1), ifh, w)
+		if err != nil {
+			return err
+		}
+		nrBytesWritten += n
+	}
+	if nrBytesWritten != int64(mdatPayloadSize) {
+		return fmt.Errorf("wrote %d instead of %d in mdat", nrBytesWritten, mdatPayloadSize)
+	}
+	return nil
+}
+
+func minUint32(a, b uint32) uint32 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/cmd/mp4ff-crop/stblcrop.go
+++ b/cmd/mp4ff-crop/stblcrop.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"github.com/edgeware/mp4ff/mp4"
+)
+
+func cropStblChildren(traks []*mp4.TrakBox, trakOuts map[uint32]*trakOut) {
+	for _, trak := range traks {
+		trakID := trak.Tkhd.TrackID
+		stbl := trak.Mdia.Minf.Stbl
+		to := trakOuts[trakID]
+		for _, ch := range stbl.Children {
+			switch ch.Type() {
+			case "stts":
+				cropStts(ch.(*mp4.SttsBox), to.lastSampleNr)
+			case "stss":
+				cropStss(ch.(*mp4.StssBox), to.lastSampleNr)
+			case "ctts":
+				cropCtts(ch.(*mp4.CttsBox), to.lastSampleNr)
+			case "stsc":
+				cropStsc(ch.(*mp4.StscBox), to.lastSampleNr)
+			case "stsz":
+				cropStsz(ch.(*mp4.StszBox), to.lastSampleNr)
+			case "sdtp":
+				cropSdtp(ch.(*mp4.SdtpBox), to.lastSampleNr)
+			case "stco":
+				updateStco(ch.(*mp4.StcoBox), to.chunkOffsets)
+			case "co64":
+				updateCo64(ch.(*mp4.Co64Box), to.chunkOffsets)
+			}
+		}
+	}
+}
+
+func cropStts(b *mp4.SttsBox, lastSampleNr uint32) {
+	var countedSamples uint32 = 0
+	var nrEntries int
+	for i := 0; i < len(b.SampleCount); i++ {
+		if countedSamples+b.SampleCount[i] >= lastSampleNr {
+			countedSamples += b.SampleCount[i]
+			nrEntries = i + 1
+			continue
+		}
+		// Now 0 or more remains in a last entry
+		nrEntries = i
+		remaining := lastSampleNr - countedSamples
+		if remaining > 0 {
+			b.SampleCount[i] = remaining
+			nrEntries = i + 1
+		}
+		break
+	}
+	b.SampleCount = b.SampleCount[:nrEntries]
+	b.SampleTimeDelta = b.SampleTimeDelta[:nrEntries]
+}
+
+func cropStss(b *mp4.StssBox, lastSampleNr uint32) {
+	nrEntries := b.EntryCount()
+	for i := uint32(0); i < nrEntries; i++ {
+		if b.SampleNumber[i] > lastSampleNr {
+			break
+		}
+		nrEntries = i + 1
+	}
+	b.SampleNumber = b.SampleNumber[:nrEntries]
+}
+
+func cropCtts(b *mp4.CttsBox, lastSampleNr uint32) {
+	var countedSamples uint32 = 0
+	var nrEntries int
+	for i := 0; i < len(b.SampleCount); i++ {
+		if countedSamples+b.SampleCount[i] <= lastSampleNr {
+			countedSamples += b.SampleCount[i]
+			nrEntries = i + 1
+			continue
+		}
+		// Now 0 or more remains in a last entry
+		remaining := lastSampleNr - countedSamples
+		if remaining > 0 {
+			b.SampleCount[i] = remaining
+			nrEntries = i + 1
+		}
+		break
+	}
+	b.SampleCount = b.SampleCount[:nrEntries]
+	b.SampleOffset = b.SampleOffset[:nrEntries]
+}
+
+func cropStsc(b *mp4.StscBox, lastSampleNr uint32) {
+	var countedSamples uint32 = 0
+	nrEntries := len(b.FirstChunk)
+	nrFullEntries := 0
+	nextChunkNr := 1
+	for i := 0; i < nrEntries-1; i++ {
+		nrChunksOfLength := b.FirstChunk[i+1] - b.FirstChunk[i]
+		nrSamplesInEntry := nrChunksOfLength * b.SamplesPerChunk[i]
+		if countedSamples+nrSamplesInEntry < lastSampleNr {
+			countedSamples += nrSamplesInEntry
+			nrFullEntries++
+			nextChunkNr += int(nrChunksOfLength)
+			continue
+		}
+		break
+	}
+	samplesLeft := lastSampleNr - countedSamples
+	if samplesLeft == 0 {
+		if nrFullEntries < nrEntries-1 {
+			b.FirstChunk = b.FirstChunk[:nrFullEntries]
+			b.SamplesPerChunk = b.SamplesPerChunk[:nrFullEntries]
+		}
+	} else {
+		partialSizeLeft := samplesLeft % b.SamplesPerChunk[nrFullEntries]
+		nrChunksOfLastSize := samplesLeft / b.SamplesPerChunk[nrFullEntries]
+		if nrChunksOfLastSize >= 1 {
+			b.FirstChunk = b.FirstChunk[:nrFullEntries+1]
+			b.SamplesPerChunk = b.SamplesPerChunk[:nrFullEntries+1]
+		} else {
+			b.FirstChunk = b.FirstChunk[:nrFullEntries]
+			b.SamplesPerChunk = b.SamplesPerChunk[:nrFullEntries]
+		}
+		nextChunkNr += int(nrChunksOfLastSize)
+		if partialSizeLeft > 0 {
+			b.FirstChunk = append(b.FirstChunk, uint32(nextChunkNr))
+			b.SamplesPerChunk = append(b.SamplesPerChunk, partialSizeLeft)
+		}
+	}
+	if len(b.SampleDescriptionID) > 0 {
+		b.SampleDescriptionID = b.SampleDescriptionID[:len(b.FirstChunk)]
+	}
+}
+
+func cropStsz(b *mp4.StszBox, lastSampleNr uint32) {
+	if b.SampleUniformSize == 0 {
+		b.SampleSize = b.SampleSize[:lastSampleNr]
+	}
+	b.SampleNumber = lastSampleNr
+}
+
+func cropSdtp(b *mp4.SdtpBox, lastSampleNr uint32) {
+	if len(b.Entries) > int(lastSampleNr) {
+		b.Entries = b.Entries[:lastSampleNr]
+	}
+}
+
+func updateStco(b *mp4.StcoBox, offsets []uint64) {
+	b.ChunkOffset = make([]uint32, len(offsets))
+	for i := range offsets {
+		b.ChunkOffset[i] = uint32(offsets[i])
+	}
+}
+
+func updateCo64(b *mp4.Co64Box, offsets []uint64) {
+	b.ChunkOffset = make([]uint64, len(offsets))
+	for i := range offsets {
+		b.ChunkOffset[i] = offsets[i]
+	}
+}

--- a/mp4/stsc.go
+++ b/mp4/stsc.go
@@ -217,13 +217,13 @@ func (b *StscBox) GetChunk(chunkNr uint32) Chunk {
 		currSamplesPerChunk = b.SamplesPerChunk[i]
 		if i < nrEntries-1 {
 			nextFirstChunk = b.FirstChunk[i+1]
+			if chunkNr < nextFirstChunk {
+				chunk.StartSampleNr = startSampleNr + (chunkNr-currFirstChunk)*currSamplesPerChunk
+				chunk.NrSamples = currSamplesPerChunk
+				return chunk
+			}
+			startSampleNr += currSamplesPerChunk * (nextFirstChunk - currFirstChunk)
 		}
-		if chunkNr < nextFirstChunk {
-			chunk.StartSampleNr = startSampleNr + (chunkNr-currFirstChunk)*currSamplesPerChunk
-			chunk.NrSamples = currSamplesPerChunk
-			return chunk
-		}
-		startSampleNr += currSamplesPerChunk * (nextFirstChunk - currFirstChunk)
 	}
 	startSampleNr += b.SamplesPerChunk[nrEntries-1] * (chunkNr - currFirstChunk)
 	chunk.StartSampleNr = startSampleNr


### PR DESCRIPTION
New tool to crop progressive mp4 files by only keeping the first N milliseconds of all tracks in the file, while leaving all the box structure intact and the interleaving intact. The actual duration being cropped depends on sync samples in the first video track, or on the audio samples if no video track is present.

A use case is generation of short versions of test content, while keeping the exact box structure of the original, except that
the mdat box is moved to the end.