### PR TITLE
fix: ffmpeg box parsing

### DIFF
--- a/mp4/ffmpeg.go
+++ b/mp4/ffmpeg.go
@@ -90,7 +90,9 @@ func DecodeData(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 
 // DecodeDataSR - decode Data (from mov_write_string_data_tag in movenc.c in ffmpeg)
 func DecodeDataSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	return &DataBox{sr.ReadBytes(hdr.payloadLen())}, sr.AccError()
+	_ = sr.ReadUint32() // Should be 1
+	_ = sr.ReadUint32() // Should be 0
+	return &DataBox{sr.ReadBytes(hdr.payloadLen() - 8)}, sr.AccError()
 }
 
 // Type - box type

--- a/mp4/ffmpeg_test.go
+++ b/mp4/ffmpeg_test.go
@@ -1,0 +1,33 @@
+package mp4
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/edgeware/mp4ff/bits"
+)
+
+func TestDecodeFFMpeg(t *testing.T) {
+	data := "0000003a696c737400000032a9746f6f0000002a64617461000000010000000048616e644272616b6520312e342e322032303231313030333030"
+	raw, err := hex.DecodeString(data)
+	if err != nil {
+		t.Error(err)
+	}
+	sr := bits.NewFixedSliceReader(raw)
+	box, err := DecodeBoxSR(0, sr)
+	if err != nil {
+		t.Error(err)
+	}
+	ilst := box.(*IlstBox)
+	sw := bits.NewFixedSliceWriter(int(ilst.Size()))
+	err = ilst.EncodeSW(sw)
+	if err != nil {
+		t.Error(err)
+	}
+	encBytes := sw.Bytes()
+	if !bytes.Equal(raw, encBytes) {
+		t.Errorf("encoded ffmpeg boxes not same as input")
+	}
+
+}


### PR DESCRIPTION
Fix parsing of ffmpeg `data` box that got broken in #123 and added test