### PR TITLE
Make boxHeader and fields public

### DIFF
--- a/mp4/audiosamplentry.go
+++ b/mp4/audiosamplentry.go
@@ -64,13 +64,13 @@ func (a *AudioSampleEntryBox) AddChild(child Box) {
 const nrAudioSampleBytesBeforeChildren = 36
 
 // DecodeAudioSampleEntry - decode mp4a... box
-func DecodeAudioSampleEntry(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeAudioSampleEntry(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
 	}
 	sr := bits.NewFixedSliceReader(data)
-	a := NewAudioSampleEntryBox(hdr.name)
+	a := NewAudioSampleEntryBox(hdr.Name)
 
 	// 14496-12 8.5.2.2 Sample entry (8 bytes)
 	sr.SkipBytes(6) // Skip 6 reserved bytes
@@ -99,18 +99,18 @@ func DecodeAudioSampleEntry(hdr boxHeader, startPos uint64, r io.Reader) (Box, e
 			a.AddChild(box)
 			pos += box.Size()
 		}
-		if pos == startPos+hdr.size {
+		if pos == startPos+hdr.Size {
 			break
-		} else if pos > startPos+hdr.size {
-			return nil, fmt.Errorf("Bad size when decoding %s", hdr.name)
+		} else if pos > startPos+hdr.Size {
+			return nil, fmt.Errorf("Bad size when decoding %s", hdr.Name)
 		}
 	}
 	return a, nil
 }
 
 // DecodeAudioSampleEntry - decode mp4a... box
-func DecodeAudioSampleEntrySR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	a := NewAudioSampleEntryBox(hdr.name)
+func DecodeAudioSampleEntrySR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	a := NewAudioSampleEntryBox(hdr.Name)
 
 	// 14496-12 8.5.2.2 Sample entry (8 bytes)
 	sr.SkipBytes(6) // Skip 6 reserved bytes
@@ -125,7 +125,7 @@ func DecodeAudioSampleEntrySR(hdr boxHeader, startPos uint64, sr bits.SliceReade
 	a.SampleRate = makeUint16FromFixed32(sr.ReadUint32())
 
 	pos := startPos + nrAudioSampleBytesBeforeChildren // Size of all previous data
-	lastPos := startPos + hdr.size
+	lastPos := startPos + hdr.Size
 	for {
 		if pos >= lastPos {
 			break

--- a/mp4/avcc.go
+++ b/mp4/avcc.go
@@ -26,7 +26,7 @@ func CreateAvcC(spsNALUs [][]byte, ppsNALUs [][]byte) (*AvcCBox, error) {
 }
 
 // DecodeAvcC - box-specific decode
-func DecodeAvcC(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeAvcC(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func DecodeAvcC(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeAvcCSR - box-specific decode
-func DecodeAvcCSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeAvcCSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	avcDecConfRec, err := avc.DecodeAVCDecConfRec(sr.ReadBytes(hdr.payloadLen()))
 	if err != nil {
 		return nil, err

--- a/mp4/boxsr.go
+++ b/mp4/boxsr.go
@@ -130,7 +130,7 @@ func DecodeBoxSR(startPos uint64, sr bits.SliceReader) (Box, error) {
 	var err error
 	var b Box
 
-	h, err := decodeHeaderSR(sr)
+	h, err := DecodeHeaderSR(sr)
 	if err != nil {
 		return nil, err
 	}
@@ -149,8 +149,8 @@ func DecodeBoxSR(startPos uint64, sr bits.SliceReader) (Box, error) {
 	return b, nil
 }
 
-// decodeHeaderSR - decode a box header (size + box type + possible largeSize) from sr
-func decodeHeaderSR(sr bits.SliceReader) (BoxHeader, error) {
+// DecodeHeaderSR - decode a box header (size + box type + possible largeSize) from sr
+func DecodeHeaderSR(sr bits.SliceReader) (BoxHeader, error) {
 	size := uint64(sr.ReadUint32())
 	boxType := sr.ReadFixedLengthString(4)
 	headerLen := boxHeaderSize

--- a/mp4/boxsr.go
+++ b/mp4/boxsr.go
@@ -123,7 +123,7 @@ func init() {
 }
 
 // BoxDecoderSR is function signature of the Box DecodeSR method
-type BoxDecoderSR func(hdr boxHeader, startPos uint64, sw bits.SliceReader) (Box, error)
+type BoxDecoderSR func(hdr BoxHeader, startPos uint64, sw bits.SliceReader) (Box, error)
 
 // DecodeBoxSR - decode a box from SliceReader
 func DecodeBoxSR(startPos uint64, sr bits.SliceReader) (Box, error) {
@@ -135,7 +135,7 @@ func DecodeBoxSR(startPos uint64, sr bits.SliceReader) (Box, error) {
 		return nil, err
 	}
 
-	d, ok := decodersSR[h.name]
+	d, ok := decodersSR[h.Name]
 
 	if !ok {
 		b, err = DecodeUnknownSR(h, startPos, sr)
@@ -143,14 +143,14 @@ func DecodeBoxSR(startPos uint64, sr bits.SliceReader) (Box, error) {
 		b, err = d(h, startPos, sr)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("decode %s: %w", h.name, err)
+		return nil, fmt.Errorf("decode %s: %w", h.Name, err)
 	}
 
 	return b, nil
 }
 
 // decodeHeaderSR - decode a box header (size + box type + possible largeSize) from sr
-func decodeHeaderSR(sr bits.SliceReader) (boxHeader, error) {
+func decodeHeaderSR(sr bits.SliceReader) (BoxHeader, error) {
 	size := uint64(sr.ReadUint32())
 	boxType := sr.ReadFixedLengthString(4)
 	headerLen := boxHeaderSize
@@ -158,9 +158,9 @@ func decodeHeaderSR(sr bits.SliceReader) (boxHeader, error) {
 		size = sr.ReadUint64()
 		headerLen += largeSizeLen
 	} else if size == 0 {
-		return boxHeader{}, fmt.Errorf("Size 0, meaning to end of file, not supported")
+		return BoxHeader{}, fmt.Errorf("Size 0, meaning to end of file, not supported")
 	}
-	return boxHeader{boxType, size, headerLen}, nil
+	return BoxHeader{boxType, size, headerLen}, nil
 }
 
 // DecodeFile - parse and decode a file from reader r with optional file options.

--- a/mp4/btrt.go
+++ b/mp4/btrt.go
@@ -14,7 +14,7 @@ type BtrtBox struct {
 }
 
 // DecodeBtrt - box-specific decode
-func DecodeBtrt(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeBtrt(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -24,7 +24,7 @@ func DecodeBtrt(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeBtrtSR - box-specific decode
-func DecodeBtrtSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeBtrtSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	b := &BtrtBox{
 		BufferSizeDB: sr.ReadUint32(),
 		MaxBitrate:   sr.ReadUint32(),

--- a/mp4/cdat.go
+++ b/mp4/cdat.go
@@ -14,7 +14,7 @@ type CdatBox struct {
 }
 
 // DecodeCdat - box-specific decode
-func DecodeCdat(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeCdat(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -26,7 +26,7 @@ func DecodeCdat(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeCdat - box-specific decode
-func DecodeCdatSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeCdatSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	b := &CdatBox{
 		Data: sr.ReadBytes(hdr.payloadLen()),
 	}

--- a/mp4/clap.go
+++ b/mp4/clap.go
@@ -19,7 +19,7 @@ type ClapBox struct {
 }
 
 // DecodeClap - box-specific decode
-func DecodeClap(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeClap(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -29,7 +29,7 @@ func DecodeClap(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeClapSR - box-specific decode
-func DecodeClapSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeClapSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	clap := ClapBox{}
 	clap.CleanApertureWidthN = sr.ReadUint32()
 	clap.CleanApertureWidthD = sr.ReadUint32()

--- a/mp4/co64.go
+++ b/mp4/co64.go
@@ -19,7 +19,7 @@ type Co64Box struct {
 }
 
 // DecodeCo64 - box-specific decode
-func DecodeCo64(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeCo64(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -29,7 +29,7 @@ func DecodeCo64(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeCo64 - box-specific decode
-func DecodeCo64SR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeCo64SR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	nrEntries := sr.ReadUint32()
 	b := &Co64Box{

--- a/mp4/container.go
+++ b/mp4/container.go
@@ -26,7 +26,7 @@ func containerSize(children []Box) uint64 {
 }
 
 // DecodeContainerChildren decodes a container box
-func DecodeContainerChildren(hdr boxHeader, startPos, endPos uint64, r io.Reader) ([]Box, error) {
+func DecodeContainerChildren(hdr BoxHeader, startPos, endPos uint64, r io.Reader) ([]Box, error) {
 	children := make([]Box, 0, 8)
 	pos := startPos
 	for {
@@ -48,7 +48,7 @@ func DecodeContainerChildren(hdr boxHeader, startPos, endPos uint64, r io.Reader
 }
 
 // DecodeContainerChildren decodes a container box
-func DecodeContainerChildrenSR(hdr boxHeader, startPos, endPos uint64, sr bits.SliceReader) ([]Box, error) {
+func DecodeContainerChildrenSR(hdr BoxHeader, startPos, endPos uint64, sr bits.SliceReader) ([]Box, error) {
 	children := make([]Box, 0, 8) // Good initial size
 	pos := startPos
 	initPos := sr.GetPos()
@@ -67,7 +67,7 @@ func DecodeContainerChildrenSR(hdr boxHeader, startPos, endPos uint64, sr bits.S
 		pos += child.Size()
 		relPosFromSize := sr.GetPos() - initPos
 		if int(pos-startPos) != relPosFromSize {
-			return nil, fmt.Errorf("child %s size mismatch in %s: %d - %d\n", child.Type(), hdr.name, pos-startPos, relPosFromSize)
+			return nil, fmt.Errorf("child %s size mismatch in %s: %d - %d\n", child.Type(), hdr.Name, pos-startPos, relPosFromSize)
 		}
 	}
 	return children, nil

--- a/mp4/cslg.go
+++ b/mp4/cslg.go
@@ -20,7 +20,7 @@ type CslgBox struct {
 }
 
 // DecodeCslg - box-specific decode
-func DecodeCslg(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeCslg(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -30,7 +30,7 @@ func DecodeCslg(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeCslgSR - box-specific decode
-func DecodeCslgSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeCslgSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	b := CslgBox{
 		Version: byte(versionAndFlags >> 24),

--- a/mp4/ctts.go
+++ b/mp4/ctts.go
@@ -17,7 +17,7 @@ type CttsBox struct {
 }
 
 // DecodeCtts - box-specific decode
-func DecodeCtts(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeCtts(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -27,7 +27,7 @@ func DecodeCtts(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeCttsSR - box-specific decode
-func DecodeCttsSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeCttsSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	entryCount := sr.ReadUint32()
 

--- a/mp4/dinf.go
+++ b/mp4/dinf.go
@@ -25,8 +25,8 @@ func (d *DinfBox) AddChild(box Box) {
 }
 
 // DecodeDinf - box-specific decode
-func DecodeDinf(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
-	l, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.size, r)
+func DecodeDinf(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
+	l, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.Size, r)
 	if err != nil {
 		return nil, err
 	}
@@ -38,8 +38,8 @@ func DecodeDinf(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeDinfSR - box-specific decode
-func DecodeDinfSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+func DecodeDinfSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/dref.go
+++ b/mp4/dref.go
@@ -36,7 +36,7 @@ func (d *DrefBox) AddChild(box Box) {
 }
 
 // DecodeDref - box-specific decode
-func DecodeDref(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeDref(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	var versionAndFlags, entryCount uint32
 	err := binary.Read(r, binary.BigEndian, &versionAndFlags)
 	if err != nil {
@@ -48,7 +48,7 @@ func DecodeDref(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 	}
 
 	// Note higher startPos for children since not simple container.
-	children, err := DecodeContainerChildren(hdr, startPos+16, startPos+hdr.size, r)
+	children, err := DecodeContainerChildren(hdr, startPos+16, startPos+hdr.Size, r)
 	if err != nil {
 		return nil, err
 	}
@@ -68,12 +68,12 @@ func DecodeDref(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeDrefSR - box-specific decode
-func DecodeDrefSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeDrefSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	entryCount := sr.ReadUint32()
 
 	// Note higher startPos for children since not simple container.
-	children, err := DecodeContainerChildrenSR(hdr, startPos+16, startPos+hdr.size, sr)
+	children, err := DecodeContainerChildrenSR(hdr, startPos+16, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/edts.go
+++ b/mp4/edts.go
@@ -18,8 +18,8 @@ type EdtsBox struct {
 }
 
 // DecodeEdts - box-specific decode
-func DecodeEdts(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
-	l, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.size, r)
+func DecodeEdts(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
+	l, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.Size, r)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +37,8 @@ func DecodeEdts(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeEdtsSR - box-specific decode
-func DecodeEdtsSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+func DecodeEdtsSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/elng.go
+++ b/mp4/elng.go
@@ -17,7 +17,7 @@ func CreateElng(language string) *ElngBox {
 }
 
 // DecodeElng - box-specific decode
-func DecodeElng(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeElng(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -29,7 +29,7 @@ func DecodeElng(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeElngSR - box-specific decode
-func DecodeElngSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeElngSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	b := &ElngBox{
 		Language: string(sr.ReadZeroTerminatedString(hdr.payloadLen())),
 	}

--- a/mp4/elst.go
+++ b/mp4/elst.go
@@ -24,7 +24,7 @@ type ElstEntry struct {
 }
 
 // DecodeElst - box-specific decode
-func DecodeElst(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeElst(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func DecodeElst(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeElstSR - box-specific decode
-func DecodeElstSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeElstSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 	entryCount := sr.ReadUint32()

--- a/mp4/emsg.go
+++ b/mp4/emsg.go
@@ -21,7 +21,7 @@ type EmsgBox struct {
 }
 
 // DecodeEmsg - box-specific decode
-func DecodeEmsg(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeEmsg(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -31,7 +31,7 @@ func DecodeEmsg(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeEmsgSR - box-specific decode
-func DecodeEmsgSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeEmsgSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	initPos := sr.GetPos()
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)

--- a/mp4/esds.go
+++ b/mp4/esds.go
@@ -84,7 +84,7 @@ func CreateEsdsBox(decConfig []byte) *EsdsBox {
 const fixedPartLen = 37
 
 // DecodeEsds - box-specific decode
-func DecodeEsds(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeEsds(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -95,7 +95,7 @@ func DecodeEsds(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeEsdsSR - box-specific decode
-func DecodeEsdsSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeEsdsSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 

--- a/mp4/ffmpeg.go
+++ b/mp4/ffmpeg.go
@@ -13,8 +13,8 @@ type CTooBox struct {
 }
 
 // DecodeCToo - box-specific decode
-func DecodeCToo(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
-	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.size, r)
+func DecodeCToo(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
+	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.Size, r)
 	if err != nil {
 		return nil, err
 	}
@@ -26,8 +26,8 @@ func DecodeCToo(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeCTooSR - box-specific decode
-func DecodeCTooSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+func DecodeCTooSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ type DataBox struct {
 }
 
 // DecodeData - decode Data (from mov_write_string_data_tag in movenc.c in ffmpeg)
-func DecodeData(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeData(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -89,7 +89,7 @@ func DecodeData(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeDataSR - decode Data (from mov_write_string_data_tag in movenc.c in ffmpeg)
-func DecodeDataSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeDataSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	_ = sr.ReadUint32() // Should be 1
 	_ = sr.ReadUint32() // Should be 0
 	return &DataBox{sr.ReadBytes(hdr.payloadLen() - 8)}, sr.AccError()

--- a/mp4/free.go
+++ b/mp4/free.go
@@ -13,17 +13,17 @@ type FreeBox struct {
 }
 
 // DecodeFree - box-specific decode
-func DecodeFree(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeFree(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
 	}
-	return &FreeBox{Name: hdr.name, notDecoded: data}, nil
+	return &FreeBox{Name: hdr.Name, notDecoded: data}, nil
 }
 
 // DecodeFreeSR - box-specific decode
-func DecodeFreeSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	return &FreeBox{Name: hdr.name, notDecoded: sr.ReadBytes(hdr.payloadLen())}, sr.AccError()
+func DecodeFreeSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	return &FreeBox{Name: hdr.Name, notDecoded: sr.ReadBytes(hdr.payloadLen())}, sr.AccError()
 }
 
 // Type - box type

--- a/mp4/frma.go
+++ b/mp4/frma.go
@@ -13,7 +13,7 @@ type FrmaBox struct {
 }
 
 // DecodeFrma - box-specific decode
-func DecodeFrma(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeFrma(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -23,7 +23,7 @@ func DecodeFrma(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeFrmaSR - box-specific decode
-func DecodeFrmaSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeFrmaSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	if hdr.payloadLen() != 4 {
 		return nil, fmt.Errorf("Frma content length is not 4")
 	}

--- a/mp4/ftyp.go
+++ b/mp4/ftyp.go
@@ -54,7 +54,7 @@ func NewFtyp(majorBrand string, minorVersion uint32, compatibleBrands []string) 
 }
 
 // DecodeFtyp - box-specific decode
-func DecodeFtyp(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeFtyp(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func DecodeFtyp(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeFtypSR - box-specific decode
-func DecodeFtypSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeFtypSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	return &FtypBox{data: sr.ReadBytes(hdr.payloadLen())}, sr.AccError()
 }
 

--- a/mp4/hdlr.go
+++ b/mp4/hdlr.go
@@ -55,7 +55,7 @@ func CreateHdlr(mediaOrHdlrType string) (*HdlrBox, error) {
 }
 
 // DecodeHdlr - box-specific decode
-func DecodeHdlr(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeHdlr(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -65,7 +65,7 @@ func DecodeHdlr(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeHdlrSR - box-specific decode
-func DecodeHdlrSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeHdlrSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	h := HdlrBox{
 		Version:     byte(versionAndFlags >> 24),

--- a/mp4/hvcc.go
+++ b/mp4/hvcc.go
@@ -27,7 +27,7 @@ func CreateHvcC(vpsNalus, spsNalus, ppsNalus [][]byte, vpsComplete, spsComplete,
 }
 
 // DecodeHvcC - box-specific decode
-func DecodeHvcC(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeHvcC(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -40,7 +40,7 @@ func DecodeHvcC(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeHvcCSR - box-specific decode
-func DecodeHvcCSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeHvcCSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	hevcDecConfRec, err := hevc.DecodeHEVCDecConfRec(sr.ReadBytes(hdr.payloadLen()))
 	return &HvcCBox{hevcDecConfRec}, err
 }

--- a/mp4/ilst.go
+++ b/mp4/ilst.go
@@ -18,8 +18,8 @@ func (b *IlstBox) AddChild(child Box) {
 }
 
 // DecodeIlstSR - box-specific decode
-func DecodeIlstSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+func DecodeIlstSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}
@@ -31,8 +31,8 @@ func DecodeIlstSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, err
 }
 
 // DecodeIlst - box-specific decode
-func DecodeIlst(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
-	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.size, r)
+func DecodeIlst(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
+	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.Size, r)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/kind.go
+++ b/mp4/kind.go
@@ -14,7 +14,7 @@ type KindBox struct {
 }
 
 // DecodeKind - box-specific decode
-func DecodeKind(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeKind(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -24,7 +24,7 @@ func DecodeKind(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeKindSR - box-specific decode
-func DecodeKindSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeKindSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	maxLen := hdr.payloadLen() - 1
 	schemeURI := sr.ReadZeroTerminatedString(maxLen)
 	maxLen = hdr.payloadLen() - 1

--- a/mp4/mdat.go
+++ b/mp4/mdat.go
@@ -23,18 +23,18 @@ type MdatBox struct {
 const maxNormalPayloadSize = (1 << 32) - 1 - 8
 
 // DecodeMdat - box-specific decode
-func DecodeMdat(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeMdat(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
 	}
-	largeSize := hdr.hdrlen > boxHeaderSize
+	largeSize := hdr.Hdrlen > boxHeaderSize
 	return &MdatBox{startPos, data, nil, 0, largeSize}, nil
 }
 
 // DecodeMdatSR - box-specific decode
-func DecodeMdatSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	largeSize := hdr.hdrlen > boxHeaderSize
+func DecodeMdatSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	largeSize := hdr.Hdrlen > boxHeaderSize
 	return &MdatBox{startPos, sr.ReadBytes(hdr.payloadLen()), nil, 0, largeSize}, nil
 }
 
@@ -44,9 +44,9 @@ func (m *MdatBox) IsLazy() bool {
 }
 
 // DecodeMdatLazily - box-specific decode but Data is not in memory
-func DecodeMdatLazily(hdr boxHeader, startPos uint64) (Box, error) {
-	largeSize := hdr.hdrlen > boxHeaderSize
-	decLazyDataSize := hdr.size - uint64(hdr.hdrlen)
+func DecodeMdatLazily(hdr BoxHeader, startPos uint64) (Box, error) {
+	largeSize := hdr.Hdrlen > boxHeaderSize
+	decLazyDataSize := hdr.Size - uint64(hdr.Hdrlen)
 	return &MdatBox{startPos, nil, nil, decLazyDataSize, largeSize}, nil
 }
 

--- a/mp4/mdhd.go
+++ b/mp4/mdhd.go
@@ -27,7 +27,7 @@ type MdhdBox struct {
 }
 
 // DecodeMdhd - Decode box
-func DecodeMdhd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeMdhd(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -37,7 +37,7 @@ func DecodeMdhd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeMdhd - Decode box
-func DecodeMdhdSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeMdhdSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 	b := MdhdBox{

--- a/mp4/mdia.go
+++ b/mp4/mdia.go
@@ -39,8 +39,8 @@ func (m *MdiaBox) AddChild(box Box) {
 }
 
 // DecodeMdia - box-specific decode
-func DecodeMdia(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
-	l, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.size, r)
+func DecodeMdia(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
+	l, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.Size, r)
 	if err != nil {
 		return nil, err
 	}
@@ -52,8 +52,8 @@ func DecodeMdia(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeMdiaSR - box-specific decode
-func DecodeMdiaSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+func DecodeMdiaSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/mehd.go
+++ b/mp4/mehd.go
@@ -15,7 +15,7 @@ type MehdBox struct {
 }
 
 // DecodeMehd - box-specific decode
-func DecodeMehd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeMehd(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -25,7 +25,7 @@ func DecodeMehd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeMehdSR - box-specific decode
-func DecodeMehdSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeMehdSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 	b := &MehdBox{

--- a/mp4/meta.go
+++ b/mp4/meta.go
@@ -36,14 +36,14 @@ func (b *MetaBox) AddChild(box Box) {
 }
 
 // DecodeMeta - box-specific decode
-func DecodeMeta(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeMeta(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	var versionAndFlags uint32
 	err := binary.Read(r, binary.BigEndian, &versionAndFlags)
 	if err != nil {
 		return nil, err
 	}
 	//Note higher startPos below since not simple container
-	children, err := DecodeContainerChildren(hdr, startPos+12, startPos+hdr.size, r)
+	children, err := DecodeContainerChildren(hdr, startPos+12, startPos+hdr.Size, r)
 	if err != nil {
 		return nil, err
 	}
@@ -58,10 +58,10 @@ func DecodeMeta(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeMetaSR - box-specific decode
-func DecodeMetaSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeMetaSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	//Note higher startPos below since not simple container
-	children, err := DecodeContainerChildrenSR(hdr, startPos+12, startPos+hdr.size, sr)
+	children, err := DecodeContainerChildrenSR(hdr, startPos+12, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/mfhd.go
+++ b/mp4/mfhd.go
@@ -16,7 +16,7 @@ type MfhdBox struct {
 }
 
 // DecodeMfhd - box-specific decode
-func DecodeMfhd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeMfhd(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func DecodeMfhd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeMfhdSR - box-specific decode
-func DecodeMfhdSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeMfhdSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 	flags := versionAndFlags & flagsMask

--- a/mp4/mfra.go
+++ b/mp4/mfra.go
@@ -17,8 +17,8 @@ type MfraBox struct {
 }
 
 // DecodeMfra - box-specific decode
-func DecodeMfra(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
-	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.size, r)
+func DecodeMfra(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
+	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.Size, r)
 	if err != nil {
 		return nil, err
 	}
@@ -34,8 +34,8 @@ func DecodeMfra(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeMfraSR - box-specific decode
-func DecodeMfraSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+func DecodeMfraSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/mfro.go
+++ b/mp4/mfro.go
@@ -15,7 +15,7 @@ type MfroBox struct {
 }
 
 // DecodeMfro - box-specific decode
-func DecodeMfro(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeMfro(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -25,7 +25,7 @@ func DecodeMfro(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeMfroSR - box-specific decode
-func DecodeMfroSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeMfroSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 
 	b := &MfroBox{

--- a/mp4/mime.go
+++ b/mp4/mime.go
@@ -15,7 +15,7 @@ type MimeBox struct {
 }
 
 // DecodeMime - box-specific decode
-func DecodeMime(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeMime(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -25,7 +25,7 @@ func DecodeMime(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeMimeSR - box-specific decode
-func DecodeMimeSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeMimeSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	b := MimeBox{
 		Version: byte(versionAndFlags >> 24),

--- a/mp4/minf.go
+++ b/mp4/minf.go
@@ -43,8 +43,8 @@ func (m *MinfBox) AddChild(box Box) {
 }
 
 // DecodeMinf - box-specific decode
-func DecodeMinf(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
-	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.size, r)
+func DecodeMinf(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
+	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.Size, r)
 	if err != nil {
 		return nil, err
 	}
@@ -56,8 +56,8 @@ func DecodeMinf(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeMinfSR - box-specific decode
-func DecodeMinfSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+func DecodeMinfSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/moof.go
+++ b/mp4/moof.go
@@ -21,14 +21,14 @@ type MoofBox struct {
 }
 
 // DecodeMoof - box-specific decode
-func DecodeMoof(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeMoof(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data := make([]byte, hdr.payloadLen())
 	_, err := r.Read(data)
 	if err != nil {
 		return nil, err
 	}
 	sr := bits.NewFixedSliceReader(data)
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}
@@ -45,8 +45,8 @@ func DecodeMoof(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeMoofSR - box-specific decode
-func DecodeMoofSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+func DecodeMoofSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/moov.go
+++ b/mp4/moov.go
@@ -62,14 +62,14 @@ func (m *MoovBox) AddChild(box Box) {
 }
 
 // DecodeMoov - box-specific decode
-func DecodeMoov(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeMoov(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data := make([]byte, hdr.payloadLen())
 	_, err := r.Read(data)
 	if err != nil {
 		return nil, err
 	}
 	sr := bits.NewFixedSliceReader(data)
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +82,8 @@ func DecodeMoov(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeMoovSR - box-specific decode
-func DecodeMoovSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+func DecodeMoovSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/mvex.go
+++ b/mp4/mvex.go
@@ -39,8 +39,8 @@ func (m *MvexBox) AddChild(box Box) {
 }
 
 // DecodeMvex - box-specific decode
-func DecodeMvex(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
-	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.size, r)
+func DecodeMvex(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
+	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.Size, r)
 	if err != nil {
 		return nil, err
 	}
@@ -52,8 +52,8 @@ func DecodeMvex(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeMvex - box-specific decode
-func DecodeMvexSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+func DecodeMvexSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/mvhd.go
+++ b/mp4/mvhd.go
@@ -38,7 +38,7 @@ func CreateMvhd() *MvhdBox {
 }
 
 // DecodeMvhd - box-specific decode
-func DecodeMvhd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeMvhd(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -48,7 +48,7 @@ func DecodeMvhd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeMvhdSR - box-specific decode
-func DecodeMvhdSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeMvhdSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 

--- a/mp4/mvhd_test.go
+++ b/mp4/mvhd_test.go
@@ -20,7 +20,7 @@ func TestMvhd(t *testing.T) {
 	}
 
 	reader := &buf
-	hdr, err := decodeHeader(reader)
+	hdr, err := DecodeHeader(reader)
 	if err != nil {
 		t.Error(err)
 	}

--- a/mp4/nmhd.go
+++ b/mp4/nmhd.go
@@ -13,7 +13,7 @@ type NmhdBox struct {
 }
 
 // DecodeNmhd - box-specific decode
-func DecodeNmhd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeNmhd(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -23,7 +23,7 @@ func DecodeNmhd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeNmhdSR - box-specific decode
-func DecodeNmhdSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeNmhdSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 
 	versionAndFlags := sr.ReadUint32()
 	sb := &NmhdBox{

--- a/mp4/pasp.go
+++ b/mp4/pasp.go
@@ -13,7 +13,7 @@ type PaspBox struct {
 }
 
 // DecodePasp - box-specific decode
-func DecodePasp(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodePasp(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -23,7 +23,7 @@ func DecodePasp(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodePaspSR - box-specific decode
-func DecodePaspSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodePaspSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	pasp := &PaspBox{}
 	pasp.HSpacing = sr.ReadUint32()
 	pasp.VSpacing = sr.ReadUint32()

--- a/mp4/prft.go
+++ b/mp4/prft.go
@@ -27,7 +27,7 @@ func CreatePrftBox(version byte, ntp uint64, mediatime uint64) *PrftBox {
 }
 
 // DecodePrft - box-specific decode
-func DecodePrft(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodePrft(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -37,7 +37,7 @@ func DecodePrft(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodePrftSR - box-specific decode
-func DecodePrftSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodePrftSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 	flags := versionAndFlags & flagsMask

--- a/mp4/pssh.go
+++ b/mp4/pssh.go
@@ -54,7 +54,7 @@ type PsshBox struct {
 }
 
 // DecodePssh - box-specific decode
-func DecodePssh(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodePssh(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func DecodePssh(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodePsshSR - box-specific decode
-func DecodePsshSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodePsshSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 

--- a/mp4/saio.go
+++ b/mp4/saio.go
@@ -16,7 +16,7 @@ type SaioBox struct {
 }
 
 // DecodeSaio - box-specific decode
-func DecodeSaio(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeSaio(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -26,7 +26,7 @@ func DecodeSaio(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeSaioSR - box-specific decode
-func DecodeSaioSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeSaioSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 	b := SaioBox{

--- a/mp4/saiz.go
+++ b/mp4/saiz.go
@@ -18,7 +18,7 @@ type SaizBox struct {
 }
 
 // DecodeSaiz - box-specific decode
-func DecodeSaiz(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeSaiz(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -28,7 +28,7 @@ func DecodeSaiz(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeSaizSR - box-specific decode
-func DecodeSaizSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeSaizSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 	b := SaizBox{

--- a/mp4/sbgp.go
+++ b/mp4/sbgp.go
@@ -22,7 +22,7 @@ type SbgpBox struct {
 }
 
 // DecodeSbgp - box-specific decode
-func DecodeSbgp(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeSbgp(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -32,7 +32,7 @@ func DecodeSbgp(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeSbgpSR - box-specific decode
-func DecodeSbgpSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeSbgpSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 

--- a/mp4/schi.go
+++ b/mp4/schi.go
@@ -22,8 +22,8 @@ func (b *SchiBox) AddChild(box Box) {
 }
 
 // DecodeSchi - box-specific decode
-func DecodeSchi(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
-	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.size, r)
+func DecodeSchi(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
+	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.Size, r)
 	if err != nil {
 		return nil, err
 	}
@@ -35,8 +35,8 @@ func DecodeSchi(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeSchiSR - box-specific decode
-func DecodeSchiSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+func DecodeSchiSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/schm.go
+++ b/mp4/schm.go
@@ -16,7 +16,7 @@ type SchmBox struct {
 }
 
 // DecodeSchm - box-specific decode
-func DecodeSchm(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeSchm(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -26,7 +26,7 @@ func DecodeSchm(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeSchmSR - box-specific decode
-func DecodeSchmSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeSchmSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 

--- a/mp4/sdtp.go
+++ b/mp4/sdtp.go
@@ -72,7 +72,7 @@ func CreateSdtpBox(entries []SdtpEntry) *SdtpBox {
 }
 
 // DecodeSdtp - box-specific decode
-func DecodeSdtp(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeSdtp(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -82,7 +82,7 @@ func DecodeSdtp(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeSdtpSR - box-specific decode
-func DecodeSdtpSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeSdtpSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 	flags := versionAndFlags & flagsMask

--- a/mp4/senc.go
+++ b/mp4/senc.go
@@ -71,7 +71,7 @@ func (s *SencBox) AddSample(sample SencSample) error {
 }
 
 // DecodeSenc - box-specific decode
-func DecodeSenc(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeSenc(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func DecodeSenc(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeSencSR - box-specific decode
-func DecodeSencSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeSencSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	sampleCount := sr.ReadUint32()
 	senc := SencBox{

--- a/mp4/sgpd.go
+++ b/mp4/sgpd.go
@@ -19,7 +19,7 @@ type SgpdBox struct {
 }
 
 // DecodeSgpd - box-specific decode
-func DecodeSgpd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeSgpd(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -29,7 +29,7 @@ func DecodeSgpd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeSgpdSR - box-specific decode
-func DecodeSgpdSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeSgpdSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 

--- a/mp4/sidx.go
+++ b/mp4/sidx.go
@@ -54,7 +54,7 @@ type SidxRef struct {
 }
 
 // DecodeSidx - box-specific decode
-func DecodeSidx(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeSidx(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func DecodeSidx(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeSidxSR - box-specific decode
-func DecodeSidxSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeSidxSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 

--- a/mp4/sinf.go
+++ b/mp4/sinf.go
@@ -28,8 +28,8 @@ func (b *SinfBox) AddChild(box Box) {
 }
 
 // DecodeSinf - box-specific decode
-func DecodeSinf(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
-	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.size, r)
+func DecodeSinf(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
+	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.Size, r)
 	if err != nil {
 		return nil, err
 	}
@@ -41,8 +41,8 @@ func DecodeSinf(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeSinfSR - box-specific decode
-func DecodeSinfSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+func DecodeSinfSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/smhd.go
+++ b/mp4/smhd.go
@@ -22,7 +22,7 @@ func CreateSmhd() *SmhdBox {
 }
 
 // DecodeSmhd - box-specific decode
-func DecodeSmhd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeSmhd(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -32,7 +32,7 @@ func DecodeSmhd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeSmhdSR - box-specific decode
-func DecodeSmhdSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeSmhdSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	b := SmhdBox{
 		Version: byte(versionAndFlags >> 24),

--- a/mp4/stbl.go
+++ b/mp4/stbl.go
@@ -79,8 +79,8 @@ func (s *StblBox) AddChild(box Box) {
 }
 
 // DecodeStbl - box-specific decode
-func DecodeStbl(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
-	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.size, r)
+func DecodeStbl(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
+	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.Size, r)
 	if err != nil {
 		return nil, err
 	}
@@ -92,8 +92,8 @@ func DecodeStbl(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeStblSR - box-specific decode
-func DecodeStblSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+func DecodeStblSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/stco.go
+++ b/mp4/stco.go
@@ -20,7 +20,7 @@ type StcoBox struct {
 }
 
 // DecodeStco - box-specific decode
-func DecodeStco(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeStco(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -30,7 +30,7 @@ func DecodeStco(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeStcoSR - box-specific decode
-func DecodeStcoSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeStcoSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	entryCount := sr.ReadUint32()
 	b := &StcoBox{

--- a/mp4/sthd.go
+++ b/mp4/sthd.go
@@ -13,7 +13,7 @@ type SthdBox struct {
 }
 
 // DecodeSthd - box-specific decode
-func DecodeSthd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeSthd(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -23,7 +23,7 @@ func DecodeSthd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeSthdSR - box-specific decode
-func DecodeSthdSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeSthdSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	sb := &SthdBox{
 		Version: byte(versionAndFlags >> 24),

--- a/mp4/stpp.go
+++ b/mp4/stpp.go
@@ -46,7 +46,7 @@ func (b *StppBox) AddChild(child Box) {
 }
 
 // DecodeStpp - Decode XMLSubtitleSampleEntry (stpp)
-func DecodeStpp(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeStpp(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -86,9 +86,9 @@ func DecodeStpp(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 			b.AddChild(box)
 			pos += box.Size()
 		}
-		if pos == startPos+hdr.size {
+		if pos == startPos+hdr.Size {
 			break
-		} else if pos > startPos+hdr.size {
+		} else if pos > startPos+hdr.Size {
 			return nil, errors.New("Bad size in stpp")
 		}
 	}
@@ -96,7 +96,7 @@ func DecodeStpp(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeStppSR - Decode XMLSubtitleSampleEntry (stpp)
-func DecodeStppSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeStppSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	payloadLen := hdr.payloadLen()
 
 	remainingBytes := func(sr bits.SliceReader, initPos, payloadLen int) int {
@@ -120,7 +120,7 @@ func DecodeStppSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, err
 	if err := sr.AccError(); err != nil {
 		return nil, fmt.Errorf("DecodeStpp: %w", err)
 	}
-	pos := startPos + uint64(hdr.hdrlen+sr.GetPos()-initPos)
+	pos := startPos + uint64(hdr.Hdrlen+sr.GetPos()-initPos)
 	for {
 		rest := remainingBytes(sr, initPos, payloadLen)
 		if rest <= 0 {

--- a/mp4/stsc.go
+++ b/mp4/stsc.go
@@ -26,7 +26,7 @@ type StscBox struct {
 }
 
 // DecodeStsc - box-specific decode
-func DecodeStsc(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeStsc(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -36,7 +36,7 @@ func DecodeStsc(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeStscSR - box-specific decode
-func DecodeStscSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeStscSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	entryCount := sr.ReadUint32()
 	b := StscBox{

--- a/mp4/stsd.go
+++ b/mp4/stsd.go
@@ -77,7 +77,7 @@ func (s *StsdBox) GetSampleDescription(index int) (Box, error) {
 }
 
 // DecodeStsd - box-specific decode
-func DecodeStsd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeStsd(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	var versionAndFlags, sampleCount uint32
 	err := binary.Read(r, binary.BigEndian, &versionAndFlags)
 	if err != nil {
@@ -88,7 +88,7 @@ func DecodeStsd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 		return nil, err
 	}
 	//Note higher startPos below since not simple container
-	children, err := DecodeContainerChildren(hdr, startPos+16, startPos+hdr.size, r)
+	children, err := DecodeContainerChildren(hdr, startPos+16, startPos+hdr.Size, r)
 	if err != nil {
 		return nil, err
 	}
@@ -110,11 +110,11 @@ func DecodeStsd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeStsdSR - box-specific decode
-func DecodeStsdSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeStsdSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	sampleCount := sr.ReadUint32()
 	//Note higher startPos below since not simple container
-	children, err := DecodeContainerChildrenSR(hdr, startPos+16, startPos+hdr.size, sr)
+	children, err := DecodeContainerChildrenSR(hdr, startPos+16, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/stss.go
+++ b/mp4/stss.go
@@ -18,7 +18,7 @@ type StssBox struct {
 }
 
 // DecodeStss - box-specific decode
-func DecodeStss(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeStss(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -28,7 +28,7 @@ func DecodeStss(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeStssSR - box-specific decode
-func DecodeStssSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeStssSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	entryCount := sr.ReadUint32()
 	b := StssBox{

--- a/mp4/stsz.go
+++ b/mp4/stsz.go
@@ -24,7 +24,7 @@ type StszBox struct {
 }
 
 // DecodeStsz - box-specific decode
-func DecodeStsz(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeStsz(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func DecodeStsz(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeStszSR - box-specific decode
-func DecodeStszSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeStszSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 
 	b := StszBox{

--- a/mp4/stts.go
+++ b/mp4/stts.go
@@ -22,7 +22,7 @@ type SttsBox struct {
 }
 
 // DecodeStts - box-specific decode
-func DecodeStts(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeStts(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -32,7 +32,7 @@ func DecodeStts(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeSttsSR - box-specific decode
-func DecodeSttsSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeSttsSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	entryCount := sr.ReadUint32()
 	b := SttsBox{

--- a/mp4/styp.go
+++ b/mp4/styp.go
@@ -54,7 +54,7 @@ func NewStyp(majorBrand string, minorVersion uint32, compatibleBrands []string) 
 }
 
 // DecodeStyp - box-specific decode
-func DecodeStyp(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeStyp(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -64,8 +64,8 @@ func DecodeStyp(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeStypSR - box-specific decode
-func DecodeStypSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	b := StypBox{data: sr.ReadBytes(int(hdr.size) - hdr.hdrlen)}
+func DecodeStypSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	b := StypBox{data: sr.ReadBytes(int(hdr.Size) - hdr.Hdrlen)}
 	return &b, sr.AccError()
 }
 

--- a/mp4/subs.go
+++ b/mp4/subs.go
@@ -56,7 +56,7 @@ type SubsSample struct {
 }
 
 // DecodeSubs - box-specific decode
-func DecodeSubs(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeSubs(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -66,7 +66,7 @@ func DecodeSubs(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeSubsSR - box-specific decode
-func DecodeSubsSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeSubsSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 

--- a/mp4/tenc.go
+++ b/mp4/tenc.go
@@ -22,7 +22,7 @@ type TencBox struct {
 }
 
 // DecodeTenc - box-specific decode
-func DecodeTenc(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeTenc(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -32,7 +32,7 @@ func DecodeTenc(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeTencSR - box-specific decode
-func DecodeTencSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeTencSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 

--- a/mp4/tfdt.go
+++ b/mp4/tfdt.go
@@ -16,7 +16,7 @@ type TfdtBox struct {
 }
 
 // DecodeTfdt - box-specific decode
-func DecodeTfdt(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeTfdt(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -40,7 +40,7 @@ func DecodeTfdt(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeTfdtSR - box-specific decode
-func DecodeTfdtSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeTfdtSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 	var baseMediaDecodeTime uint64

--- a/mp4/tfdt_test.go
+++ b/mp4/tfdt_test.go
@@ -10,10 +10,10 @@ func TestTfdtReadingV0(t *testing.T) {
 	byteData, _ := hex.DecodeString("00000010746664740000000000ffffff")
 
 	r := bytes.NewReader(byteData[8:]) // Don't include header
-	bHdr := boxHeader{
-		name:   "tfdt",
-		size:   uint64(len(byteData)),
-		hdrlen: 8,
+	bHdr := BoxHeader{
+		Name:   "tfdt",
+		Size:   uint64(len(byteData)),
+		Hdrlen: 8,
 	}
 	box, _ := DecodeTfdt(bHdr, 0, r)
 	tfdt := box.(*TfdtBox)
@@ -30,10 +30,10 @@ func TestTfdtReadingV1(t *testing.T) {
 	byteData, _ := hex.DecodeString("0000001474666474010000000000000000ffffff")
 
 	r := bytes.NewReader(byteData[8:]) // Don't include header
-	bHdr := boxHeader{
-		name:   "tfdt",
-		size:   uint64(len(byteData)),
-		hdrlen: 8,
+	bHdr := BoxHeader{
+		Name:   "tfdt",
+		Size:   uint64(len(byteData)),
+		Hdrlen: 8,
 	}
 	box, _ := DecodeTfdt(bHdr, 0, r)
 	tfdt := box.(*TfdtBox)
@@ -50,10 +50,10 @@ func TestTfdtWriteV1(t *testing.T) {
 	byteData, _ := hex.DecodeString("0000001474666474010000000000000000ffffff")
 
 	r := bytes.NewReader(byteData[8:]) // Don't include header
-	bHdr := boxHeader{
-		name:   "tfdt",
-		size:   uint64(len(byteData)),
-		hdrlen: 8,
+	bHdr := BoxHeader{
+		Name:   "tfdt",
+		Size:   uint64(len(byteData)),
+		Hdrlen: 8,
 	}
 	box, err := DecodeTfdt(bHdr, 0, r)
 	if err != nil {

--- a/mp4/tfhd.go
+++ b/mp4/tfhd.go
@@ -29,7 +29,7 @@ type TfhdBox struct {
 }
 
 // DecodeTfhd - box-specific decode
-func DecodeTfhd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeTfhd(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -40,7 +40,7 @@ func DecodeTfhd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeTfhdSR - box-specific decode
-func DecodeTfhdSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeTfhdSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 	flags := versionAndFlags & flagsMask

--- a/mp4/tfhd_test.go
+++ b/mp4/tfhd_test.go
@@ -14,7 +14,7 @@ func TestTfhd(t *testing.T) {
 
 	inRawBox, _ := hex.DecodeString(tfhdRawBox)
 	inbuf := bytes.NewBuffer(inRawBox)
-	hdr, err := decodeHeader(inbuf)
+	hdr, err := DecodeHeader(inbuf)
 	if err != nil {
 		t.Error(err)
 	}

--- a/mp4/tfra.go
+++ b/mp4/tfra.go
@@ -28,7 +28,7 @@ type TfraEntry struct {
 }
 
 // DecodeTfra - box-specific decode
-func DecodeTfra(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeTfra(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func DecodeTfra(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeTfraSR - box-specific decode
-func DecodeTfraSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeTfraSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 

--- a/mp4/tkhd.go
+++ b/mp4/tkhd.go
@@ -37,7 +37,7 @@ func CreateTkhd() *TkhdBox {
 }
 
 // DecodeTkhd - box-specific decode
-func DecodeTkhd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeTkhd(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func DecodeTkhd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeTkhdSR - box-specific decode
-func DecodeTkhdSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeTkhdSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 	flags := versionAndFlags & flagsMask

--- a/mp4/tkhd_test.go
+++ b/mp4/tkhd_test.go
@@ -20,7 +20,7 @@ func TestTkhd(t *testing.T) {
 	}
 
 	reader := &buf
-	hdr, err := decodeHeader(reader)
+	hdr, err := DecodeHeader(reader)
 	if err != nil {
 		t.Error(err)
 	}

--- a/mp4/topboxinfo.go
+++ b/mp4/topboxinfo.go
@@ -21,18 +21,18 @@ func GetTopBoxInfoList(rs io.ReadSeeker, stopBoxType string) ([]TopBoxInfo, erro
 	var topBoxList []TopBoxInfo
 
 	for {
-		h, err := decodeHeader(rs)
+		h, err := DecodeHeader(rs)
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
 			return nil, err
 		}
-		if h.name == stopBoxType {
+		if h.Name == stopBoxType {
 			break
 		}
-		topBoxList = append(topBoxList, TopBoxInfo{h.name, h.size, pos})
-		nextBoxStart := pos + h.size
+		topBoxList = append(topBoxList, TopBoxInfo{h.Name, h.Size, pos})
+		nextBoxStart := pos + h.Size
 		ipos, err := rs.Seek(int64(nextBoxStart), io.SeekStart)
 		if err != nil {
 			return nil, err

--- a/mp4/traf.go
+++ b/mp4/traf.go
@@ -26,8 +26,8 @@ type TrafBox struct {
 }
 
 // DecodeTraf - box-specific decode
-func DecodeTraf(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
-	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.size, r)
+func DecodeTraf(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
+	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.Size, r)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +42,8 @@ func DecodeTraf(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeTrafSR - box-specific decode
-func DecodeTrafSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+func DecodeTrafSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/trak.go
+++ b/mp4/trak.go
@@ -41,8 +41,8 @@ func (t *TrakBox) AddChild(box Box) {
 }
 
 // DecodeTrak - box-specific decode
-func DecodeTrak(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
-	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.size, r)
+func DecodeTrak(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
+	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.Size, r)
 	if err != nil {
 		return nil, err
 	}
@@ -54,8 +54,8 @@ func DecodeTrak(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeTrakSR - box-specific decode
-func DecodeTrakSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+func DecodeTrakSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/tref.go
+++ b/mp4/tref.go
@@ -18,8 +18,8 @@ func (b *TrefBox) AddChild(box Box) {
 }
 
 // DecodeTref - box-specific decode
-func DecodeTref(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
-	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.size, r)
+func DecodeTref(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
+	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.Size, r)
 	if err != nil {
 		return nil, err
 	}
@@ -31,8 +31,8 @@ func DecodeTref(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeTrefSR - box-specific decode
-func DecodeTrefSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+func DecodeTrefSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ type TrefTypeBox struct {
 }
 
 // DecodeTrefType - box-specific decode
-func DecodeTrefType(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeTrefType(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -92,10 +92,10 @@ func DecodeTrefType(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeTrefTypeSR - box-specific decode
-func DecodeTrefTypeSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeTrefTypeSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	nrIds := hdr.payloadLen() / 4
 	b := TrefTypeBox{
-		Name:     hdr.name,
+		Name:     hdr.Name,
 		TrackIDs: make([]uint32, nrIds),
 	}
 	for i := 0; i < nrIds; i++ {

--- a/mp4/trep.go
+++ b/mp4/trep.go
@@ -22,7 +22,7 @@ func (b *TrepBox) AddChild(child Box) {
 }
 
 // DecodeTrep - box-specific decode
-func DecodeTrep(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeTrep(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -32,7 +32,7 @@ func DecodeTrep(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeTrepSR - box-specific decode
-func DecodeTrepSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeTrepSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	trackID := sr.ReadUint32()
 	b := TrepBox{
@@ -41,7 +41,7 @@ func DecodeTrepSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, err
 		TrackID: trackID,
 	}
 	//Note higher startPos below since not simple container
-	children, err := DecodeContainerChildrenSR(hdr, startPos+16, startPos+hdr.size, sr)
+	children, err := DecodeContainerChildrenSR(hdr, startPos+16, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/trex.go
+++ b/mp4/trex.go
@@ -28,7 +28,7 @@ func CreateTrex(trackID uint32) *TrexBox {
 }
 
 // DecodeTrex - box-specific decode
-func DecodeTrex(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeTrex(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func DecodeTrex(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeTrexSR - box-specific decode
-func DecodeTrexSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeTrexSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 
 	b := TrexBox{

--- a/mp4/trun.go
+++ b/mp4/trun.go
@@ -29,7 +29,7 @@ const TrunSampleFlagsPresentFlag uint32 = 0x400
 const TrunSampleCompositionTimeOffsetPresentFlag uint32 = 0x800
 
 // DecodeTrun - box-specific decode
-func DecodeTrun(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeTrun(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -77,7 +77,7 @@ func DecodeTrun(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeTrun - box-specific decode
-func DecodeTrunSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeTrunSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	sampleCount := sr.ReadUint32()
 	t := &TrunBox{

--- a/mp4/udta.go
+++ b/mp4/udta.go
@@ -20,8 +20,8 @@ func (b *UdtaBox) AddChild(box Box) {
 }
 
 // DecodeUdta - box-specific decode
-func DecodeUdta(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
-	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.size, r)
+func DecodeUdta(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
+	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.Size, r)
 	if err != nil {
 		return nil, err
 	}
@@ -33,8 +33,8 @@ func DecodeUdta(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeUdtaSR - box-specific decode
-func DecodeUdtaSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+func DecodeUdtaSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/unknown.go
+++ b/mp4/unknown.go
@@ -15,7 +15,7 @@ type UnknownBox struct {
 }
 
 // DecodeUnknown - decode an unknown box
-func DecodeUnknown(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeUnknown(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -25,8 +25,8 @@ func DecodeUnknown(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeUnknown - decode an unknown box
-func DecodeUnknownSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	return &UnknownBox{hdr.name, hdr.size, sr.ReadBytes(hdr.payloadLen())}, sr.AccError()
+func DecodeUnknownSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	return &UnknownBox{hdr.Name, hdr.Size, sr.ReadBytes(hdr.payloadLen())}, sr.AccError()
 }
 
 // Type - return box type

--- a/mp4/url.go
+++ b/mp4/url.go
@@ -18,7 +18,7 @@ type URLBox struct {
 const dataIsSelfContainedFlag = 0x000001
 
 // DecodeURLBox - box-specific decode
-func DecodeURLBox(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeURLBox(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -28,7 +28,7 @@ func DecodeURLBox(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeURLBoxSR - box-specific decode
-func DecodeURLBoxSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeURLBoxSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	version := byte(versionAndFlags >> 24)
 	flags := versionAndFlags & flagsMask

--- a/mp4/uuid.go
+++ b/mp4/uuid.go
@@ -40,7 +40,7 @@ type TfrfData struct {
 }
 
 // DecodeUUIDBox - decode a UUID box including tfxd or tfrf
-func DecodeUUIDBox(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeUUIDBox(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -50,7 +50,7 @@ func DecodeUUIDBox(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeUUIDBoxSR - decode a UUID box including tfxd or tfrf
-func DecodeUUIDBoxSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeUUIDBoxSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	b := &UUIDBox{}
 	b.UUID = string(sr.ReadBytes(16))
 	switch b.UUID {

--- a/mp4/uuid_test.go
+++ b/mp4/uuid_test.go
@@ -14,7 +14,7 @@ func TestTfxd(t *testing.T) {
 
 	inRawBox, _ := hex.DecodeString(uuidTfxdRaw)
 	inbuf := bytes.NewBuffer(inRawBox)
-	hdr, err := decodeHeader(inbuf)
+	hdr, err := DecodeHeader(inbuf)
 	if err != nil {
 		t.Error(err)
 	}
@@ -44,7 +44,7 @@ func TestTfrf(t *testing.T) {
 
 	inRawBox, _ := hex.DecodeString(uuidTfrfRaw)
 	inbuf := bytes.NewBuffer(inRawBox)
-	hdr, err := decodeHeader(inbuf)
+	hdr, err := DecodeHeader(inbuf)
 	if err != nil {
 		t.Error(err)
 	}

--- a/mp4/visualsampleentry.go
+++ b/mp4/visualsampleentry.go
@@ -73,7 +73,7 @@ func (b *VisualSampleEntryBox) AddChild(child Box) {
 }
 
 // DecodeVisualSampleEntry - decode avc1/avc3/... box
-func DecodeVisualSampleEntry(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeVisualSampleEntry(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -83,8 +83,8 @@ func DecodeVisualSampleEntry(hdr boxHeader, startPos uint64, r io.Reader) (Box, 
 }
 
 // DecodeVisualSampleEntrySR - decode avc1/avc3/hvc1/hev1... box
-func DecodeVisualSampleEntrySR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	b := VisualSampleEntryBox{name: hdr.name}
+func DecodeVisualSampleEntrySR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	b := VisualSampleEntryBox{name: hdr.Name}
 
 	// 14496-12 8.5.2.2 Sample entry (8 bytes)
 	sr.SkipBytes(6) // Skip 6 reserved bytes
@@ -114,7 +114,7 @@ func DecodeVisualSampleEntrySR(hdr boxHeader, startPos uint64, sr bits.SliceRead
 	// Now there may be clap and pasp boxes
 	// 14496-15  5.4.2.1.2 avcC should be inside avc1, avc3 box
 	pos := startPos + 86 // Size of all previous data
-	endPos := startPos + uint64(hdr.hdrlen) + uint64(hdr.payloadLen())
+	endPos := startPos + uint64(hdr.Hdrlen) + uint64(hdr.payloadLen())
 	for {
 		if pos >= endPos {
 			break

--- a/mp4/vmhd.go
+++ b/mp4/vmhd.go
@@ -23,7 +23,7 @@ func CreateVmhd() *VmhdBox {
 }
 
 // DecodeVmhd - box-specific decode
-func DecodeVmhd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeVmhd(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -33,7 +33,7 @@ func DecodeVmhd(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeVmhdSR - box-specific decode
-func DecodeVmhdSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeVmhdSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	versionAndFlags := sr.ReadUint32()
 	b := VmhdBox{
 		Version:      byte(versionAndFlags >> 24),

--- a/mp4/wvtt.go
+++ b/mp4/wvtt.go
@@ -45,7 +45,7 @@ func (b *WvttBox) AddChild(child Box) {
 const nrWvttBytesBeforeChildren = 16
 
 // DecodeWvtt - Decoder wvtt Sample Entry (wvtt)
-func DecodeWvtt(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeWvtt(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -55,13 +55,13 @@ func DecodeWvtt(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeWvttSR - Decoder wvtt Sample Entry (wvtt)
-func DecodeWvttSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeWvttSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	w := WvttBox{}
 	// 14496-12 8.5.2.2 Sample entry (8 bytes)
 	sr.SkipBytes(6) // Skip 6 reserved bytes
 	w.DataReferenceIndex = sr.ReadUint16()
 	pos := startPos + nrWvttBytesBeforeChildren
-	endPos := startPos + uint64(hdr.hdrlen+hdr.payloadLen())
+	endPos := startPos + uint64(hdr.Hdrlen+hdr.payloadLen())
 	for {
 		if pos >= endPos {
 			break
@@ -163,7 +163,7 @@ type VttCBox struct {
 }
 
 // DecodeVttC - box-specific decode
-func DecodeVttC(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeVttC(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -173,7 +173,7 @@ func DecodeVttC(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeVttCSR - box-specific decode
-func DecodeVttCSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeVttCSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	return &VttCBox{Config: sr.ReadFixedLengthString(hdr.payloadLen())}, sr.AccError()
 }
 
@@ -223,7 +223,7 @@ type VlabBox struct {
 }
 
 // DecodeVlab - box-specific decode
-func DecodeVlab(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeVlab(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -233,7 +233,7 @@ func DecodeVlab(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeVlabSR - box-specific decode
-func DecodeVlabSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeVlabSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	return &VlabBox{SourceLabel: sr.ReadFixedLengthString(hdr.payloadLen())}, sr.AccError()
 }
 
@@ -290,12 +290,12 @@ func (b *VtteBox) Type() string {
 }
 
 // DecodeVtte - box-specific decode
-func DecodeVtte(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeVtte(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	return &VtteBox{}, nil
 }
 
 // DecodeVtteSR - box-specific decode
-func DecodeVtteSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeVtteSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	return &VtteBox{}, nil
 }
 
@@ -353,8 +353,8 @@ func (b *VttcBox) AddChild(child Box) {
 }
 
 // DecodeVttc - box-specific decode
-func DecodeVttc(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
-	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.size, r)
+func DecodeVttc(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
+	children, err := DecodeContainerChildren(hdr, startPos+8, startPos+hdr.Size, r)
 	if err != nil {
 		return nil, err
 	}
@@ -366,8 +366,8 @@ func DecodeVttc(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeVttcSR - box-specific decode
-func DecodeVttcSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
-	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.size, sr)
+func DecodeVttcSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+	children, err := DecodeContainerChildrenSR(hdr, startPos+8, startPos+hdr.Size, sr)
 	if err != nil {
 		return nil, err
 	}
@@ -416,7 +416,7 @@ type VsidBox struct {
 }
 
 // DecodeVsid - box-specific decode
-func DecodeVsid(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeVsid(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -426,7 +426,7 @@ func DecodeVsid(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeVsidSR - box-specific decode
-func DecodeVsidSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeVsidSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	return &VsidBox{SourceID: sr.ReadUint32()}, sr.AccError()
 }
 
@@ -477,7 +477,7 @@ type CtimBox struct {
 }
 
 // DecodeCtim - box-specific decode
-func DecodeCtim(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeCtim(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -487,7 +487,7 @@ func DecodeCtim(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeCtimSR - box-specific decode
-func DecodeCtimSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeCtimSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	return &CtimBox{CueCurrentTime: sr.ReadFixedLengthString(hdr.payloadLen())}, sr.AccError()
 }
 
@@ -537,7 +537,7 @@ type IdenBox struct {
 }
 
 // DecodeIden - box-specific decode
-func DecodeIden(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeIden(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -547,7 +547,7 @@ func DecodeIden(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeIdenSR - box-specific decode
-func DecodeIdenSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeIdenSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	return &IdenBox{CueID: sr.ReadFixedLengthString(hdr.payloadLen())}, sr.AccError()
 }
 
@@ -597,7 +597,7 @@ type SttgBox struct {
 }
 
 // DecodeSttg - box-specific decode
-func DecodeSttg(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeSttg(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -607,7 +607,7 @@ func DecodeSttg(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeSttgSR - box-specific decode
-func DecodeSttgSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeSttgSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	return &SttgBox{Settings: sr.ReadFixedLengthString(hdr.payloadLen())}, sr.AccError()
 }
 
@@ -657,7 +657,7 @@ type PaylBox struct {
 }
 
 // DecodePayl - box-specific decode
-func DecodePayl(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodePayl(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -667,7 +667,7 @@ func DecodePayl(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodePaylSR - box-specific decode
-func DecodePaylSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodePaylSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	return &PaylBox{CueText: sr.ReadFixedLengthString(hdr.payloadLen())}, sr.AccError()
 }
 
@@ -717,7 +717,7 @@ type VttaBox struct {
 }
 
 // DecodeVtta - box-specific decode
-func DecodeVtta(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
+func DecodeVtta(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data, err := readBoxBody(r, hdr)
 	if err != nil {
 		return nil, err
@@ -727,7 +727,7 @@ func DecodeVtta(hdr boxHeader, startPos uint64, r io.Reader) (Box, error) {
 }
 
 // DecodeVttaSR - box-specific decode
-func DecodeVttaSR(hdr boxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
+func DecodeVttaSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	return &VttaBox{CueAdditionalText: sr.ReadFixedLengthString(hdr.payloadLen())}, sr.AccError()
 }
 


### PR DESCRIPTION
`boxHeader` is used in `BoxDecoder` functions, however, this struct and its
fields were never public. This changes the struct and fields to be
public as well as the `decodeHeader` function.

This might seem like a breaking change for codebases using mp4ff.
However, since `boxHeader` was never public `BoxDecoder` functions could
not be called directly (appart from passing `nil`).