### PR TITLE
Fix incomplete reads

### DIFF
--- a/examples/segmenter/segmenter.go
+++ b/examples/segmenter/segmenter.go
@@ -156,12 +156,9 @@ func (s *Segmenter) GetFullSamplesForInterval(mp4f *mp4.File, tr *Track, startSa
 				return nil, err
 			}
 			sampleData = make([]byte, size)
-			n, err := rs.Read(sampleData)
+			_, err = io.ReadFull(rs, sampleData)
 			if err != nil {
 				return nil, err
-			}
-			if n != int(size) {
-				return nil, fmt.Errorf("Read %d bytes instead of %d", n, size)
 			}
 		} else {
 			offsetInMdatData := uint64(offset) - mdatPayloadStart

--- a/mp4/mdat.go
+++ b/mp4/mdat.go
@@ -190,12 +190,9 @@ func (m *MdatBox) ReadData(start, size int64, rs io.ReadSeeker) ([]byte, error) 
 		}
 
 		buf := make([]byte, size)
-		n, err := rs.Read(buf)
+		_, err = io.ReadFull(rs, buf)
 		if err != nil {
 			return nil, err
-		}
-		if int64(n) != size {
-			return nil, fmt.Errorf("lazy mdat mode - expects to read %d bytes, but only read %d bytes", size, n)
 		}
 		return buf, nil
 	}

--- a/mp4/moof.go
+++ b/mp4/moof.go
@@ -23,7 +23,7 @@ type MoofBox struct {
 // DecodeMoof - box-specific decode
 func DecodeMoof(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data := make([]byte, hdr.payloadLen())
-	_, err := r.Read(data)
+	_, err := io.ReadFull(r, data)
 	if err != nil {
 		return nil, err
 	}

--- a/mp4/moov.go
+++ b/mp4/moov.go
@@ -64,7 +64,7 @@ func (m *MoovBox) AddChild(box Box) {
 // DecodeMoov - box-specific decode
 func DecodeMoov(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	data := make([]byte, hdr.payloadLen())
-	_, err := r.Read(data)
+	_, err := io.ReadFull(r, data)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently, it is assumed that `io.Reader` will fill the buffer, but [Go's
interface documentation](https://github.com/golang/go/blob/851ecea4cc99ab276109493477b2c7e30c253ea8/src/io/io.go#L60-L61) allows for incomplete reads. An example might be
a buffered network stream that only returns immediately available data.
Instead, `io.ReadFull` can be used to try to fill the given buffer.