### PR TITLE
Flexible video sample entries

### DIFF
--- a/avc/avcdecoderconfigurationrecord.go
+++ b/avc/avcdecoderconfigurationrecord.go
@@ -30,25 +30,30 @@ type DecConfRec struct {
 }
 
 // CreateAVCDecConfRec - Create an AVCDecConfRec based on SPS and PPS
-func CreateAVCDecConfRec(spsNALUs [][]byte, ppsNALUs [][]byte) (*DecConfRec, error) {
+func CreateAVCDecConfRec(spsNALUs [][]byte, ppsNALUs [][]byte, includePS bool) (*DecConfRec, error) {
 
 	sps, err := ParseSPSNALUnit(spsNALUs[0], false) // false -> parse only start of VUI
 	if err != nil {
 		return nil, err
 	}
 
-	return &DecConfRec{
+	drc := DecConfRec{
 		AVCProfileIndication: byte(sps.Profile),
 		ProfileCompatibility: byte(sps.ProfileCompatibility),
 		AVCLevelIndication:   byte(sps.Level),
-		SPSnalus:             spsNALUs,
-		PPSnalus:             ppsNALUs,
+		SPSnalus:             nil,
+		PPSnalus:             nil,
 		ChromaFormat:         1,
 		BitDepthLumaMinus1:   0,
 		BitDepthChromaMinus1: 0,
 		NumSPSExt:            0,
 		NoTrailingInfo:       false,
-	}, nil
+	}
+	if includePS {
+		drc.SPSnalus = spsNALUs
+		drc.PPSnalus = ppsNALUs
+	}
+	return &drc, nil
 }
 
 // DecodeAVCDecConfRec - decode an AVCDecConfRec

--- a/avc/avcdecoderconfigurationrecord.go
+++ b/avc/avcdecoderconfigurationrecord.go
@@ -29,10 +29,13 @@ type DecConfRec struct {
 	NoTrailingInfo       bool // To handle strange cases where trailing info is missing
 }
 
-// CreateAVCDecConfRec - Create an AVCDecConfRec based on SPS and PPS
-func CreateAVCDecConfRec(spsNALUs [][]byte, ppsNALUs [][]byte, includePS bool) (*DecConfRec, error) {
+// CreateAVCDecConfRec - extract information from sps and insert sps, pps if includePS set
+func CreateAVCDecConfRec(spsNalus [][]byte, ppsNalus [][]byte, includePS bool) (*DecConfRec, error) {
+	if len(spsNalus) == 0 {
+		return nil, fmt.Errorf("no SPS NALU supported. Needed to extract fundamental information")
+	}
 
-	sps, err := ParseSPSNALUnit(spsNALUs[0], false) // false -> parse only start of VUI
+	sps, err := ParseSPSNALUnit(spsNalus[0], false) // false -> parse only start of VUI
 	if err != nil {
 		return nil, err
 	}
@@ -50,8 +53,8 @@ func CreateAVCDecConfRec(spsNALUs [][]byte, ppsNALUs [][]byte, includePS bool) (
 		NoTrailingInfo:       false,
 	}
 	if includePS {
-		drc.SPSnalus = spsNALUs
-		drc.PPSnalus = ppsNALUs
+		drc.SPSnalus = spsNalus
+		drc.PPSnalus = ppsNalus
 	}
 	return &drc, nil
 }

--- a/examples/initcreator/main.go
+++ b/examples/initcreator/main.go
@@ -87,7 +87,7 @@ func writeVideoHEVCInitSegment() error {
 	init := mp4.CreateEmptyInit()
 	init.AddEmptyTrack(videoTimescale, "video", "und")
 	trak := init.Moov.Trak
-	err := trak.SetHEVCDescriptor("hvc1", vpsNALUs, spsNALUs, ppsNALUs)
+	err := trak.SetHEVCDescriptor("hvc1", vpsNALUs, spsNALUs, ppsNALUs, true)
 	if err != nil {
 		return err
 	}

--- a/examples/initcreator/main.go
+++ b/examples/initcreator/main.go
@@ -62,7 +62,8 @@ func writeVideoAVCInitSegment() error {
 	init := mp4.CreateEmptyInit()
 	init.AddEmptyTrack(videoTimescale, "video", "und")
 	trak := init.Moov.Trak
-	err := trak.SetAVCDescriptor("avc1", spsNALUs, ppsNALUs)
+	includePS := true
+	err := trak.SetAVCDescriptor("avc1", spsNALUs, ppsNALUs, includePS)
 	if err != nil {
 		return err
 	}

--- a/hevc/hevcdecoderconfigurationrecord.go
+++ b/hevc/hevcdecoderconfigurationrecord.go
@@ -10,7 +10,7 @@ import (
 
 // HEVC errors
 var (
-	ErrLengthSize = errors.New("Can only handle 4byte NALU length size")
+	ErrLengthSize = errors.New("can only handle 4byte NALU length size")
 )
 
 // DecConfRec - HEVCDecoderConfigurationRecord
@@ -65,9 +65,12 @@ func (n *NaluArray) Complete() byte {
 	return n.completeAndType >> 7
 }
 
-// CreateHEVCDecConfRec - extract information from vps, sps, pps and fill HEVCDecConfRec with that
+// CreateHEVCDecConfRec - extract information from sps and insert vps, sps, pps if includePS set
 func CreateHEVCDecConfRec(vpsNalus, spsNalus, ppsNalus [][]byte,
 	vpsComplete, spsComplete, ppsComplete, includePS bool) (DecConfRec, error) {
+	if len(spsNalus) == 0 {
+		return DecConfRec{}, fmt.Errorf("no SPS NALU supported. Needed to extract fundamental information")
+	}
 	sps, err := ParseSPSNALUnit(spsNalus[0])
 	if err != nil {
 		return DecConfRec{}, err

--- a/hevc/hevcdecoderconfigurationrecord.go
+++ b/hevc/hevcdecoderconfigurationrecord.go
@@ -48,10 +48,11 @@ func NewNaluArray(complete bool, naluType NaluType, nalus [][]byte) *NaluArray {
 	if complete {
 		completeBit = 0x80
 	}
-	return &NaluArray{
+	na := NaluArray{
 		completeAndType: completeBit | byte(naluType),
-		Nalus:           nalus,
+		Nalus:           nil,
 	}
+	return &na
 }
 
 // NaluType - return NaluType for NaluArray
@@ -65,15 +66,18 @@ func (n *NaluArray) Complete() byte {
 }
 
 // CreateHEVCDecConfRec - extract information from vps, sps, pps and fill HEVCDecConfRec with that
-func CreateHEVCDecConfRec(vpsNalus, spsNalus, ppsNalus [][]byte, vpsComplete, spsComplete, ppsComplete bool) (DecConfRec, error) {
+func CreateHEVCDecConfRec(vpsNalus, spsNalus, ppsNalus [][]byte,
+	vpsComplete, spsComplete, ppsComplete, includePS bool) (DecConfRec, error) {
 	sps, err := ParseSPSNALUnit(spsNalus[0])
 	if err != nil {
 		return DecConfRec{}, err
 	}
 	var naluArrays []NaluArray
-	naluArrays = append(naluArrays, *NewNaluArray(vpsComplete, NALU_VPS, vpsNalus))
-	naluArrays = append(naluArrays, *NewNaluArray(spsComplete, NALU_SPS, spsNalus))
-	naluArrays = append(naluArrays, *NewNaluArray(ppsComplete, NALU_PPS, ppsNalus))
+	if includePS {
+		naluArrays = append(naluArrays, *NewNaluArray(vpsComplete, NALU_VPS, vpsNalus))
+		naluArrays = append(naluArrays, *NewNaluArray(spsComplete, NALU_SPS, spsNalus))
+		naluArrays = append(naluArrays, *NewNaluArray(ppsComplete, NALU_PPS, ppsNalus))
+	}
 	ptf := sps.ProfileTierLevel
 	return DecConfRec{
 		ConfigurationVersion:             1,

--- a/hevc/hevcdecoderconfigurationrecord_test.go
+++ b/hevc/hevcdecoderconfigurationrecord_test.go
@@ -1,0 +1,66 @@
+package hevc
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestCreateDecConfRec(t *testing.T) {
+	testCases := []struct {
+		vpsHex    string
+		spsHex    string
+		ppsHex    string
+		complete  bool
+		includePS bool
+		errorMsg  string
+	}{
+		{
+			vpsHex:    "",
+			spsHex:    "",
+			ppsHex:    "",
+			complete:  false,
+			includePS: false,
+			errorMsg:  "no SPS NALU supported. Needed to extract fundamental information",
+		},
+		{
+			vpsHex:    "0000000140010c01ffff016000000300900000030000030078959809",
+			spsHex:    "00000001420101016000000300900000030000030078a00502016965959a4932bc05a80808082000000300200000030321",
+			ppsHex:    "000000014401c172b46240",
+			complete:  true,
+			includePS: true,
+			errorMsg:  "",
+		},
+	}
+	for _, tc := range testCases {
+		vpsNalus := createNalusFromHex(tc.vpsHex)
+		spsNalus := createNalusFromHex(tc.spsHex)
+		ppsNalus := createNalusFromHex(tc.ppsHex)
+		dcr, err := CreateHEVCDecConfRec(vpsNalus, spsNalus, ppsNalus,
+			tc.complete, tc.complete, tc.complete, tc.includePS)
+		if tc.errorMsg != "" {
+			if err.Error() != tc.errorMsg {
+				t.Errorf("got error %q instead of %q", err.Error(), tc.errorMsg)
+			}
+		} else {
+			if len(dcr.NaluArrays) != 3 {
+				t.Errorf("got %d NALU arrays instead of 3", len(dcr.NaluArrays))
+			}
+		}
+	}
+}
+
+func createNalusFromHex(hexStr string) [][]byte {
+	if hexStr == "" {
+		return nil
+	}
+	startCode := "00000001"
+	parts := strings.Split(hexStr, startCode)
+	nalusHex := parts[1:]
+	nalus := make([][]byte, 0, len(nalusHex))
+	for _, nx := range nalusHex {
+		nalu, _ := hex.DecodeString(nx)
+		nalus = append(nalus, nalu)
+	}
+	return nalus
+}

--- a/mp4/avcc.go
+++ b/mp4/avcc.go
@@ -16,8 +16,8 @@ type AvcCBox struct {
 }
 
 // CreateAvcC - Create an avcC box based on SPS and PPS
-func CreateAvcC(spsNALUs [][]byte, ppsNALUs [][]byte) (*AvcCBox, error) {
-	avcDecConfRec, err := avc.CreateAVCDecConfRec(spsNALUs, ppsNALUs)
+func CreateAvcC(spsNALUs [][]byte, ppsNALUs [][]byte, includePS bool) (*AvcCBox, error) {
+	avcDecConfRec, err := avc.CreateAVCDecConfRec(spsNALUs, ppsNALUs, includePS)
 	if err != nil {
 		return nil, fmt.Errorf("CreateAvcDecDecConfRec: %w", err)
 	}

--- a/mp4/hvcc.go
+++ b/mp4/hvcc.go
@@ -16,9 +16,10 @@ type HvcCBox struct {
 }
 
 // CreateHvcC - create an hvcC box based on VPS, SPS and PPS and signal completeness
-func CreateHvcC(vpsNalus, spsNalus, ppsNalus [][]byte, vpsComplete, spsComplete, ppsComplete bool) (*HvcCBox, error) {
+// If includePS is false, the nalus are not included, but information from sps is extracted.
+func CreateHvcC(vpsNalus, spsNalus, ppsNalus [][]byte, vpsComplete, spsComplete, ppsComplete, includePS bool) (*HvcCBox, error) {
 	hevcDecConfRec, err := hevc.CreateHEVCDecConfRec(vpsNalus, spsNalus, ppsNalus,
-		vpsComplete, spsComplete, ppsComplete)
+		vpsComplete, spsComplete, ppsComplete, includePS)
 	if err != nil {
 		return nil, fmt.Errorf("CreateHEVCDecConfRec: %w", err)
 	}

--- a/mp4/hvcc_test.go
+++ b/mp4/hvcc_test.go
@@ -24,7 +24,8 @@ func TestHvcC(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	hvcC, err := CreateHvcC([][]byte{vpsNalu}, [][]byte{spsNalu}, [][]byte{ppsNalu}, true, true, true)
+	includePS := true
+	hvcC, err := CreateHvcC([][]byte{vpsNalu}, [][]byte{spsNalu}, [][]byte{ppsNalu}, true, true, true, includePS)
 	if err != nil {
 		t.Error(err)
 	}

--- a/mp4/initsegment.go
+++ b/mp4/initsegment.go
@@ -178,9 +178,12 @@ func CreateEmptyTrak(trackID, timeScale uint32, mediaType, language string) *Tra
 }
 
 // SetAVCDescriptor - Set AVC SampleDescriptor based on SPS and PPS
-func (t *TrakBox) SetAVCDescriptor(sampleDescriptorType string, spsNALUs, ppsNALUs [][]byte) error {
+func (t *TrakBox) SetAVCDescriptor(sampleDescriptorType string, spsNALUs, ppsNALUs [][]byte, includePS bool) error {
 	if sampleDescriptorType != "avc1" && sampleDescriptorType != "avc3" {
 		return fmt.Errorf("sampleDescriptorType %s not allowed", sampleDescriptorType)
+	}
+	if sampleDescriptorType == "avc1" && !includePS {
+		return fmt.Errorf("cannot make avc1 descriptor without parameter sets")
 	}
 	avcSPS, err := avc.ParseSPSNALUnit(spsNALUs[0], false)
 	if err != nil {
@@ -190,7 +193,7 @@ func (t *TrakBox) SetAVCDescriptor(sampleDescriptorType string, spsNALUs, ppsNAL
 	t.Tkhd.Height = Fixed32(avcSPS.Height << 16) // This is display height
 	stsd := t.Mdia.Minf.Stbl.Stsd
 
-	avcC, err := CreateAvcC(spsNALUs, ppsNALUs)
+	avcC, err := CreateAvcC(spsNALUs, ppsNALUs, includePS)
 	if err != nil {
 		return err
 	}

--- a/mp4/initsegment.go
+++ b/mp4/initsegment.go
@@ -200,8 +200,8 @@ func (t *TrakBox) SetAVCDescriptor(sampleDescriptorType string, spsNALUs, ppsNAL
 	return nil
 }
 
-// SetHEVCDescriptor - Set HEVC SampleDescriptor based on VPS, SPS, and PPS
-func (t *TrakBox) SetHEVCDescriptor(sampleDescriptorType string, vpsNALUs, spsNALUs, ppsNALUs [][]byte) error {
+// SetHEVCDescriptor - Set HEVC SampleDescriptor based on descriptorType and VPS, SPS, and PPS
+func (t *TrakBox) SetHEVCDescriptor(sampleDescriptorType string, vpsNALUs, spsNALUs, ppsNALUs [][]byte, includePS bool) error {
 	if sampleDescriptorType != "hvc1" && sampleDescriptorType != "hev1" {
 		return fmt.Errorf("sampleDescriptorType %s not allowed", sampleDescriptorType)
 	}
@@ -214,7 +214,14 @@ func (t *TrakBox) SetHEVCDescriptor(sampleDescriptorType string, vpsNALUs, spsNA
 	t.Tkhd.Height = Fixed32(height << 16) // This is display height
 	stsd := t.Mdia.Minf.Stbl.Stsd
 
-	hvcC, err := CreateHvcC(vpsNALUs, spsNALUs, ppsNALUs, true, true, true)
+	// hvc1 must include parameter sets (PS) and they must be complete
+	// hev1 may include PS and they may not be complete
+	// here we choose to include PS in both cases
+	completePS := sampleDescriptorType == "hvc1"
+	if sampleDescriptorType == "hvc1" && !includePS {
+		return fmt.Errorf("must include parameter sets for hvc1")
+	}
+	hvcC, err := CreateHvcC(vpsNALUs, spsNALUs, ppsNALUs, completePS, completePS, completePS, includePS)
 	if err != nil {
 		return err
 	}

--- a/mp4/initsegment_test.go
+++ b/mp4/initsegment_test.go
@@ -157,7 +157,7 @@ func TestGenerateInitSegment(t *testing.T) {
 	init := CreateEmptyInit()
 	init.AddEmptyTrack(180000, "video", "und")
 	trak := init.Moov.Trak
-	err := trak.SetAVCDescriptor("avc3", spsData, ppsData)
+	err := trak.SetAVCDescriptor("avc3", spsData, ppsData, true)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
One can now choose to include parameter sets in the avc3 and hev1 sample entries.
The hev1 sample entry is also no longer signaled complete.