### PR TITLE
mp4: preliminary PIFF support

### DIFF
--- a/mp4/traf.go
+++ b/mp4/traf.go
@@ -266,6 +266,8 @@ func (t *TrafBox) RemoveEncryptionBoxes() uint64 {
 		case "senc":
 			nrBytesRemoved += ch.Size()
 			t.Senc = nil
+		case "uuid":
+			nrBytesRemoved += ch.Size()
 		default:
 			remainingChildren = append(remainingChildren, ch)
 		}


### PR DESCRIPTION
mp4/uuid.go: recognize PIFF to avoid panics

mp4/traf.go: remove PIFF boxes after decryption, so that file is playable

Fix #146