### PR TITLE
fix: error instead of panic for unknown uuid

### DIFF
--- a/mp4/uuid.go
+++ b/mp4/uuid.go
@@ -2,6 +2,7 @@ package mp4
 
 import (
 	"encoding/hex"
+	"fmt"
 	"io"
 
 	"github.com/edgeware/mp4ff/bits"
@@ -69,8 +70,8 @@ func DecodeUUIDBoxSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, 
 		}
 		b.Tfrf = tfrf
 	default:
-		// err := fmt.Errorf("Unknown uuid=%s", b.UUID)
-		// return nil, err
+		err := fmt.Errorf("unknown uuid=%q", hex.EncodeToString([]byte(b.UUID)))
+		return nil, err
 	}
 
 	return b, sr.AccError()

--- a/mp4/uuid.go
+++ b/mp4/uuid.go
@@ -1,25 +1,81 @@
 package mp4
 
 import (
+	"bytes"
 	"encoding/hex"
+	"fmt"
 	"io"
+	"strings"
 
 	"github.com/edgeware/mp4ff/bits"
 )
 
 const (
-	uuidTfxd = "\x6d\x1d\x9b\x05\x42\xd5\x44\xe6\x80\xe2\x14\x1d\xaf\xf7\x57\xb2"
-	uuidTfrf = "\xd4\x80\x7e\xf2\xca\x39\x46\x95\x8e\x54\x26\xcb\x9e\x46\xa7\x9f"
+	// UUIDTfxd - MSS tfxd UUID
+	UUIDTfxd = "6d1d9b05-42d5-44e6-80e2-141daff757b2"
+
+	// UUIDTfrf - MSS tfrf UUID
+	UUIDTfrf = "d4807ef2-ca39-4695-8e54-26cb9e46a79f"
+)
+
+//uuid - compact representation of UUID
+type uuid [16]byte
+
+// String - UUID-formatted string
+func (u uuid) String() string {
+	hexStr := hex.EncodeToString(u[:])
+	return fmt.Sprintf("%s-%s-%s-%s-%s", hexStr[:8], hexStr[8:12], hexStr[12:16], hexStr[16:20], hexStr[20:])
+}
+
+// Equal - compare with other uuid
+func (u uuid) Equal(a uuid) bool {
+	return bytes.Equal(u[:], a[:])
+}
+
+// createUUID - create uuid from string
+func createUUID(u string) (uuid, error) {
+	var a uuid
+	stripped := strings.ReplaceAll(u, "-", "")
+	b, err := hex.DecodeString(stripped)
+	if err != nil || len(b) != 16 {
+		return a, fmt.Errorf("bad uuid string: %s", u)
+	}
+	_ = copy(a[:], b)
+	return a, nil
+}
+
+// mustCreateUUID - create uuid from string. Panic for bad string
+func mustCreateUUID(u string) uuid {
+	b, err := createUUID(u)
+	if err != nil {
+		panic(err.Error())
+	}
+	return b
+}
+
+var (
+	uuidTfxd uuid = mustCreateUUID(UUIDTfxd)
+	uuidTfrf uuid = mustCreateUUID(UUIDTfrf)
 )
 
 // UUIDBox - Used as container for MSS boxes tfxd and tfrf
-// If not known UUID, the data is stored as UnknownData
+// For unknown UUID, the data after the UUID is stored as UnknownPayload
 type UUIDBox struct {
-	UUID           string // 16 bytes
-	SubType        string
+	uuid           uuid
 	Tfxd           *TfxdData
 	Tfrf           *TfrfData
 	UnknownPayload []byte
+}
+
+// UUID - Return UUID as formatted string
+func (u *UUIDBox) UUID() string {
+	return u.uuid.String()
+}
+
+// UUID - Set UUID from string
+func (u *UUIDBox) SetUUID(uuid string) (err error) {
+	u.uuid, err = createUUID(uuid)
+	return err
 }
 
 // TfxdData - MSS TfxdBox data after UUID part
@@ -54,24 +110,21 @@ func DecodeUUIDBox(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 // DecodeUUIDBoxSR - decode a UUID box including tfxd or tfrf
 func DecodeUUIDBoxSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, error) {
 	b := &UUIDBox{}
-	b.UUID = string(sr.ReadBytes(16))
-	switch b.UUID {
-	case uuidTfxd:
-		b.SubType = "tfxd"
+	copy(b.uuid[:], sr.ReadBytes(16))
+	switch b.UUID() {
+	case UUIDTfxd:
 		tfxd, err := decodeTfxd(sr)
 		if err != nil {
 			return nil, err
 		}
 		b.Tfxd = tfxd
-	case uuidTfrf:
-		b.SubType = "tfrf"
+	case UUIDTfrf:
 		tfrf, err := decodeTfrf(sr)
 		if err != nil {
 			return nil, err
 		}
 		b.Tfrf = tfrf
 	default:
-		b.SubType = "unknown"
 		b.UnknownPayload = sr.ReadBytes(int(hdr.Size) - 8 - 16)
 	}
 
@@ -86,10 +139,10 @@ func (b *UUIDBox) Type() string {
 // Size - return calculated size including tfxd/tfrf
 func (b *UUIDBox) Size() uint64 {
 	var size uint64 = 8 + 16
-	switch b.SubType {
-	case "tfxd":
+	switch u := b.uuid; {
+	case u.Equal(uuidTfxd):
 		size += b.Tfxd.size()
-	case "tfrf":
+	case u.Equal(uuidTfrf):
 		size += b.Tfrf.size()
 	default:
 		size += uint64(len(b.UnknownPayload))
@@ -114,11 +167,11 @@ func (b *UUIDBox) EncodeSW(sw bits.SliceWriter) error {
 	if err != nil {
 		return err
 	}
-	sw.WriteString(b.UUID, false)
-	switch b.SubType {
-	case "tfxd":
+	sw.WriteBytes(b.uuid[:])
+	switch u := b.uuid; {
+	case u.Equal(uuidTfxd):
 		err = b.Tfxd.encode(sw)
-	case "tfrf":
+	case u.Equal(uuidTfrf):
 		err = b.Tfrf.encode(sw)
 	default:
 		sw.WriteBytes(b.UnknownPayload)
@@ -127,6 +180,18 @@ func (b *UUIDBox) EncodeSW(sw bits.SliceWriter) error {
 		return err
 	}
 	return sw.AccError()
+}
+
+// SubType - interpret the UUID as a known sub type or unknown
+func (b *UUIDBox) SubType() string {
+	switch u := b.uuid; {
+	case u.Equal(uuidTfxd):
+		return "tfxd"
+	case u.Equal(uuidTfrf):
+		return "tfrf"
+	default:
+		return "unknown"
+	}
 }
 
 func decodeTfxd(s bits.SliceReader) (*TfxdData, error) {
@@ -215,11 +280,11 @@ func (t *TfrfData) encode(sw bits.SliceWriter) error {
 // Info - box-specific info
 func (b *UUIDBox) Info(w io.Writer, specificBoxLevels, indent, indentStep string) error {
 	bd := newInfoDumper(w, indent, b, -1, 0)
-	bd.write(" - uuid: %s", hex.EncodeToString([]byte(b.UUID)))
-	bd.write(" - subType: %s", b.SubType)
+	bd.write(" - uuid: %s", b.uuid)
+	bd.write(" - subType: %s", b.SubType())
 	level := getInfoLevel(b, specificBoxLevels)
 	if level > 0 {
-		switch b.SubType {
+		switch b.SubType() {
 		case "tfxd":
 			bd.write(" - absTime=%d absDur=%d", b.Tfxd.FragmentAbsoluteTime, b.Tfxd.FragmentAbsoluteDuration)
 		case "tfrf":

--- a/mp4/uuid_test.go
+++ b/mp4/uuid_test.go
@@ -36,8 +36,8 @@ func TestUUIDVariants(t *testing.T) {
 			t.Error(err)
 		}
 		uBox := uuidRead.(*UUIDBox)
-		if uBox.SubType != ti.expectedSubType {
-			t.Errorf("got subtype %s instead of %s", uBox.SubType, ti.expectedSubType)
+		if uBox.SubType() != ti.expectedSubType {
+			t.Errorf("got subtype %s instead of %s", uBox.SubType(), ti.expectedSubType)
 		}
 
 		outbuf := &bytes.Buffer{}
@@ -54,6 +54,36 @@ func TestUUIDVariants(t *testing.T) {
 				fmt.Printf("%3d %02x %02x\n", i, inRawBox[i], outRawBox[i])
 			}
 			t.Errorf("%s: Non-matching in and out binaries", ti.expectedSubType)
+		}
+	}
+}
+
+func TestSetUUID(t *testing.T) {
+	testCases := []struct {
+		uuidStr    string
+		expected   uuid
+		shouldFail bool
+	}{
+		{
+			uuidStr:    "6d1d9b05-42d5-44e6-80e2-141daff757b2",
+			shouldFail: false,
+		},
+		{
+			uuidStr:    "6d1d9b05-42d5-44e6-80e2-141daff757",
+			shouldFail: true,
+		},
+	}
+	for i, tc := range testCases {
+		u := UUIDBox{}
+		err := u.SetUUID(tc.uuidStr)
+		if tc.shouldFail {
+			if err == nil {
+				t.Errorf("case %d did not fail as expected", i)
+			}
+			continue
+		}
+		if u.UUID() != tc.uuidStr {
+			t.Errorf("got %s instead of %s", u.UUID(), tc.uuidStr)
 		}
 	}
 }

--- a/mp4/uuid_test.go
+++ b/mp4/uuid_test.go
@@ -7,65 +7,53 @@ import (
 	"testing"
 )
 
-const uuidTfxdRaw = "0000002c757569646d1d9b0542d544e680e2141daff757b201000000000105c649bda4000000000000054600"
-const uuidTfrfRaw = "0000002d75756964d4807ef2ca3946958e5426cb9e46a79f0100000001000105c649c2ea000000000000054600"
+func TestUUIDVariants(t *testing.T) {
 
-func TestTfxd(t *testing.T) {
-
-	inRawBox, _ := hex.DecodeString(uuidTfxdRaw)
-	inbuf := bytes.NewBuffer(inRawBox)
-	hdr, err := DecodeHeader(inbuf)
-	if err != nil {
-		t.Error(err)
-	}
-	uuidRead, err := DecodeUUIDBox(hdr, 0, inbuf)
-	if err != nil {
-		t.Error(err)
-	}
-
-	outbuf := &bytes.Buffer{}
-
-	err = uuidRead.Encode(outbuf)
-	if err != nil {
-		t.Error(err)
+	testInputs := []struct {
+		expectedSubType string
+		rawData         string
+	}{
+		{
+			"tfxd", "0000002c757569646d1d9b0542d544e680e2141daff757b201000000000105c649bda4000000000000054600",
+		},
+		{
+			"tfrf", "0000002d75756964d4807ef2ca3946958e5426cb9e46a79f0100000001000105c649c2ea000000000000054600",
+		},
+		{
+			"unknown", "0000002c757569646e1d9b0542d544e680e2141daff757b201000000000105c649bda4000000000000054600",
+		},
 	}
 
-	outRawBox := outbuf.Bytes()
-
-	if !bytes.Equal(inRawBox, outRawBox) {
-		for i := 0; i < len(inRawBox); i++ {
-			fmt.Printf("%3d %02x %02x\n", i, inRawBox[i], outRawBox[i])
+	for _, ti := range testInputs {
+		inRawBox, _ := hex.DecodeString(ti.rawData)
+		inbuf := bytes.NewBuffer(inRawBox)
+		hdr, err := DecodeHeader(inbuf)
+		if err != nil {
+			t.Error(err)
 		}
-		t.Error("Non-matching in and out binaries")
-	}
-}
-
-func TestTfrf(t *testing.T) {
-
-	inRawBox, _ := hex.DecodeString(uuidTfrfRaw)
-	inbuf := bytes.NewBuffer(inRawBox)
-	hdr, err := DecodeHeader(inbuf)
-	if err != nil {
-		t.Error(err)
-	}
-	uuidRead, err := DecodeUUIDBox(hdr, 0, inbuf)
-	if err != nil {
-		t.Error(err)
-	}
-
-	outbuf := &bytes.Buffer{}
-
-	err = uuidRead.Encode(outbuf)
-	if err != nil {
-		t.Error(err)
-	}
-
-	outRawBox := outbuf.Bytes()
-
-	if !bytes.Equal(inRawBox, outRawBox) {
-		for i := 0; i < len(inRawBox); i++ {
-			fmt.Printf("%3d %02x %02x\n", i, inRawBox[i], outRawBox[i])
+		uuidRead, err := DecodeUUIDBox(hdr, 0, inbuf)
+		if err != nil {
+			t.Error(err)
 		}
-		t.Error("Non-matching in and out binaries")
+		uBox := uuidRead.(*UUIDBox)
+		if uBox.SubType != ti.expectedSubType {
+			t.Errorf("got subtype %s instead of %s", uBox.SubType, ti.expectedSubType)
+		}
+
+		outbuf := &bytes.Buffer{}
+
+		err = uuidRead.Encode(outbuf)
+		if err != nil {
+			t.Error(err)
+		}
+
+		outRawBox := outbuf.Bytes()
+
+		if !bytes.Equal(inRawBox, outRawBox) {
+			for i := 0; i < len(inRawBox); i++ {
+				fmt.Printf("%3d %02x %02x\n", i, inRawBox[i], outRawBox[i])
+			}
+			t.Errorf("%s: Non-matching in and out binaries", ti.expectedSubType)
+		}
 	}
 }


### PR DESCRIPTION
Decode and encode UUIDBox with unknown UUID values.
This covers the case of parsing an unknown PIFF box reported in #146