### PR TITLE
fix: check encryption scheme in example/decrypt-cenc

### DIFF
--- a/examples/decrypt-cenc/main.go
+++ b/examples/decrypt-cenc/main.go
@@ -99,6 +99,9 @@ func decryptMP4withCenc(r io.Reader, key []byte, w io.Writer) error {
 				if err != nil {
 					return err
 				}
+				if sinf.Schm.SchemeType != "cenc" {
+					return fmt.Errorf("enryption scheme is %s and not cenc", sinf.Schm.SchemeType)
+				}
 				tracks = append(tracks, trackInfo{
 					trackID: trackID,
 					sinf:    sinf,
@@ -108,6 +111,9 @@ func decryptMP4withCenc(r io.Reader, key []byte, w io.Writer) error {
 				sinf, err := enca.RemoveEncryption()
 				if err != nil {
 					return err
+				}
+				if sinf.Schm.SchemeType != "cenc" {
+					return fmt.Errorf("enryption scheme is %s and not cenc", sinf.Schm.SchemeType)
 				}
 				tracks = append(tracks, trackInfo{
 					trackID: trackID,


### PR DESCRIPTION
example/decrypt-cenc crashes when given a cbcs encrypted file with constant IV.

An example file is given by #150.

This PR gives a proper error message that cbcs is being used.