### PR TITLE
[mp4ff-nallister] Add a new option to print raw bytes of NAL units

### DIFF
--- a/cmd/mp4ff-nallister/main.go
+++ b/cmd/mp4ff-nallister/main.go
@@ -42,6 +42,7 @@ func main() {
 	annexB := flag.Bool("annexb", false, "Input is Annex B stream file")
 	version := flag.Bool("version", false, "Get mp4ff version")
 	seiLevel := flag.Int("sei", 0, "Level of SEI information (1 is interpret, 2 is dump hex)")
+	printRaw := flag.Int("raw", 0, "nr raw NAL unit bytes to print")
 
 	flag.Parse()
 
@@ -67,9 +68,9 @@ func main() {
 			log.Fatal(err)
 		}
 		if *codec == "avc" {
-			err = printAVCNalus(nalus, 0, 0, *seiLevel, *parameterSets)
+			err = printAVCNalus(nalus, 0, 0, *seiLevel, *parameterSets, *printRaw)
 		} else {
-			err = printHEVCNalus(nalus, 0, 0, *seiLevel, *parameterSets)
+			err = printHEVCNalus(nalus, 0, 0, *seiLevel, *parameterSets, *printRaw)
 		}
 		if err != nil {
 			log.Fatal(err)
@@ -90,21 +91,21 @@ func main() {
 	// Need to handle progressive files as well as fragmented files
 
 	if !parsedMp4.IsFragmented() {
-		err = parseProgressiveMp4(parsedMp4, *maxNrSamples, *codec, *seiLevel, *parameterSets)
+		err = parseProgressiveMp4(parsedMp4, *maxNrSamples, *codec, *seiLevel, *parameterSets, *printRaw)
 		if err != nil {
 			fmt.Printf("Error: %s\n", err)
 			os.Exit(1)
 		}
 		return
 	}
-	err = parseFragmentedMp4(parsedMp4, *maxNrSamples, *codec, *seiLevel, *parameterSets)
+	err = parseFragmentedMp4(parsedMp4, *maxNrSamples, *codec, *seiLevel, *parameterSets, *printRaw)
 	if err != nil {
 		fmt.Printf("Error: %s\n", err)
 		os.Exit(1)
 	}
 }
 
-func parseProgressiveMp4(f *mp4.File, maxNrSamples int, codec string, seiLevel int, parameterSets bool) error {
+func parseProgressiveMp4(f *mp4.File, maxNrSamples int, codec string, seiLevel int, parameterSets bool, nrRaw int) error {
 	videoTrak, ok := findFirstVideoTrak(f.Moov)
 	if !ok {
 		return fmt.Errorf("No video track found")
@@ -143,9 +144,9 @@ func parseProgressiveMp4(f *mp4.File, maxNrSamples int, codec string, seiLevel i
 		}
 		switch codec {
 		case "avc", "h.264", "h264":
-			err = printAVCNalus(nalus, sampleNr, decTime+uint64(cto), seiLevel, parameterSets)
+			err = printAVCNalus(nalus, sampleNr, decTime+uint64(cto), seiLevel, parameterSets, nrRaw)
 		case "hevc", "h.265", "h265":
-			err = printHEVCNalus(nalus, sampleNr, decTime+uint64(cto), seiLevel, parameterSets)
+			err = printHEVCNalus(nalus, sampleNr, decTime+uint64(cto), seiLevel, parameterSets, nrRaw)
 		default:
 			return fmt.Errorf("Unknown codec: %s", codec)
 		}
@@ -180,7 +181,7 @@ func getChunkOffset(stbl *mp4.StblBox, chunkNr int) int64 {
 	panic("Neither stco nor co64 is set")
 }
 
-func parseFragmentedMp4(f *mp4.File, maxNrSamples int, codec string, seiLevel int, parameterSets bool) error {
+func parseFragmentedMp4(f *mp4.File, maxNrSamples int, codec string, seiLevel int, parameterSets bool, nrRaw int) error {
 	var trex *mp4.TrexBox
 	if f.Init != nil { // Auto-detect codec if moov box is there
 		moov := f.Init.Moov
@@ -213,9 +214,9 @@ func parseFragmentedMp4(f *mp4.File, maxNrSamples int, codec string, seiLevel in
 		}
 		switch codec {
 		case "avc", "h.264", "h264":
-			err = printAVCNalus(nalus, i+1, s.PresentationTime(), seiLevel, parameterSets)
+			err = printAVCNalus(nalus, i+1, s.PresentationTime(), seiLevel, parameterSets, nrRaw)
 		case "hevc", "h.265", "h265":
-			err = printHEVCNalus(nalus, i+1, s.PresentationTime(), seiLevel, parameterSets)
+			err = printHEVCNalus(nalus, i+1, s.PresentationTime(), seiLevel, parameterSets, nrRaw)
 		default:
 			return fmt.Errorf("Unknown codec: %s", codec)
 		}
@@ -230,7 +231,7 @@ func parseFragmentedMp4(f *mp4.File, maxNrSamples int, codec string, seiLevel in
 	return nil
 }
 
-func printAVCNalus(nalus [][]byte, nr int, pts uint64, seiLevel int, parameterSets bool) error {
+func printAVCNalus(nalus [][]byte, nr int, pts uint64, seiLevel int, parameterSets bool, nrRaw int) error {
 	msg := ""
 	var seiNALUs [][]byte
 	totLen := 0
@@ -252,7 +253,12 @@ func printAVCNalus(nalus [][]byte, nr int, pts uint64, seiLevel int, parameterSe
 				seiNALUs = append(seiNALUs, nalu)
 			}
 		}
-		msg += fmt.Sprintf(" %s %s(%dB)", naluType, imgType, len(nalu))
+		if nrRaw > 0 {
+			msg += fmt.Sprintf(" %s %s(%dB)\n", naluType, imgType, len(nalu))
+			msg += hex.EncodeToString(getStart(nalu, nrRaw)) + "\n"
+		} else {
+			msg += fmt.Sprintf(" %s %s(%dB)", naluType, imgType, len(nalu))
+		}
 	}
 	fmt.Printf("Sample %d, pts=%d (%dB):%s\n", nr, pts, totLen, msg)
 	printSEINALus(seiNALUs, "avc", seiLevel)
@@ -270,7 +276,7 @@ func printAVCNalus(nalus [][]byte, nr int, pts uint64, seiLevel int, parameterSe
 	return nil
 }
 
-func printHEVCNalus(nalus [][]byte, nr int, pts uint64, seiLevel int, parameterSets bool) error {
+func printHEVCNalus(nalus [][]byte, nr int, pts uint64, seiLevel int, parameterSets bool, nrRaw int) error {
 	msg := ""
 	var seiNALUs [][]byte
 	totLen := 0
@@ -281,6 +287,12 @@ func printHEVCNalus(nalus [][]byte, nr int, pts uint64, seiLevel int, parameterS
 		}
 		naluType := hevc.GetNaluType(nalu[0])
 		msg += fmt.Sprintf(" %s (%dB)", naluType, len(nalu))
+		if nrRaw > 0 {
+			msg += fmt.Sprintf(" %s (%dB)\n", naluType, len(nalu))
+			msg += hex.EncodeToString(getStart(nalu, nrRaw)) + "\n"
+		} else {
+			msg += fmt.Sprintf(" %s (%dB)", naluType, len(nalu))
+		}
 		if seiLevel > 0 && (naluType == hevc.NALU_SEI_PREFIX || naluType == hevc.NALU_SEI_SUFFIX) {
 			seiNALUs = append(seiNALUs, nalu)
 		}
@@ -338,4 +350,11 @@ func printSEINALus(seiNALUs [][]byte, codec string, seiLevel int) {
 			}
 		}
 	}
+}
+
+func getStart(data []byte, maxNrBytes int) []byte {
+	if len(data) > maxNrBytes {
+		return data[:maxNrBytes]
+	}
+	return data
 }

--- a/cmd/mp4ff-nallister/main.go
+++ b/cmd/mp4ff-nallister/main.go
@@ -254,8 +254,8 @@ func printAVCNalus(nalus [][]byte, nr int, pts uint64, seiLevel int, parameterSe
 			}
 		}
 		if nrRaw > 0 {
-			msg += fmt.Sprintf(" %s %s(%dB)\n", naluType, imgType, len(nalu))
-			msg += hex.EncodeToString(getStart(nalu, nrRaw)) + "\n"
+			msg += fmt.Sprintf("\n %s %s(%dB)", naluType, imgType, len(nalu))
+			msg += fmt.Sprintf(" raw: %s", bytesToStringN(nalu, nrRaw))
 		} else {
 			msg += fmt.Sprintf(" %s %s(%dB)", naluType, imgType, len(nalu))
 		}
@@ -286,10 +286,9 @@ func printHEVCNalus(nalus [][]byte, nr int, pts uint64, seiLevel int, parameterS
 			msg += ","
 		}
 		naluType := hevc.GetNaluType(nalu[0])
-		msg += fmt.Sprintf(" %s (%dB)", naluType, len(nalu))
 		if nrRaw > 0 {
-			msg += fmt.Sprintf(" %s (%dB)\n", naluType, len(nalu))
-			msg += hex.EncodeToString(getStart(nalu, nrRaw)) + "\n"
+			msg += fmt.Sprintf("\n %s (%dB)", naluType, len(nalu))
+			msg += fmt.Sprintf(" raw: %s", bytesToStringN(nalu, nrRaw))
 		} else {
 			msg += fmt.Sprintf(" %s (%dB)", naluType, len(nalu))
 		}
@@ -352,9 +351,9 @@ func printSEINALus(seiNALUs [][]byte, codec string, seiLevel int) {
 	}
 }
 
-func getStart(data []byte, maxNrBytes int) []byte {
+func bytesToStringN(data []byte, maxNrBytes int) string {
 	if len(data) > maxNrBytes {
-		return data[:maxNrBytes]
+		return hex.EncodeToString(data[:maxNrBytes]) + "..."
 	}
-	return data
+	return hex.EncodeToString(data)
 }


### PR DESCRIPTION
Example output:
1. Print single sample:
```
> mp4ff-nallister -c "hevc" -m 1 asset_with_video_track.cmfv
   Sample 1, pts=7200 (211B): AUD_35 (3B), VPS_32 (24B), SPS_33 (45B), PPS_34 (7B), RAP_IDR_20 (112B)
```

2. Print single sample with an extra 112 raw bytes of each NAL unit
```
> mp4ff-nallister -c "hevc" -m 1 -raw 112 asset_with_video_track.cmfv
   Sample 1, pts=7200 (211B):
   AUD_35 (3B) raw: 460150,
   VPS_32 (24B) raw: 40010c01ffff016000000300900000030000030078959809,
   SPS_33 (45B) raw: 420101016000000300900000030000030078a00502016965959a4932bc05a80808082000000300200000030321,
   PPS_34 (7B) raw: 4401c172b46240,
   RAP_IDR_20 (112B) raw: 2801af11316ce63170f49300bfff41985cf2277637ca1905205a942000003120a8b04641a42227d00000030000ba80930af2180000030000030003ae8700000300000300000300105000000300000300000300077c000003000003000003000003000003000003000003000003002920
```

3. Print three samples with an extra 112 raw bytes of each NAL unit
```
> mp4ff-nallister -c "hevc" -m 3 -raw 112  asset_with_video_track.cmfv
Sample 1, pts=7200 (211B):
 AUD_35 (3B) raw: 460150,
 VPS_32 (24B) raw: 40010c01ffff016000000300900000030000030078959809,
 SPS_33 (45B) raw: 420101016000000300900000030000030078a00502016965959a4932bc05a80808082000000300200000030321,
 PPS_34 (7B) raw: 4401c172b46240,
 RAP_IDR_20 (112B) raw: 2801af11316ce63170f49300bfff41985cf2277637ca1905205a942000003120a8b04641a42227d00000030000ba80930af2180000030000030003ae8700000300000300000300105000000300000300000300077c000003000003000003000003000003000003000003000003002920
Sample 2, pts=25200 (51B):
 AUD_35 (3B) raw: 460150,
 NonRAP_Trail_1 (40B) raw: 0201d0294be10c208188e86650fd59badb0bb0cc80d71b3207449ab2064c87004a400001d7000828
Sample 3, pts=18000 (45B):
 AUD_35 (3B) raw: 460150,
 NonRAP_Trail_1 (34B) raw: 0201e0649d7820a19aada89082068efde80072405c8007ac0000a4800003760016f0
```

4. Print single sample (some NALUs have a quite a big size)
```
> mp4ff-nallister -c "hevc" -m 1 other_asset_with_video_track.cmfvv
   Sample 1, pts=2000 (81137B): AUD_35 (3B), VPS_32 (33B), SPS_33 (57B), PPS_34 (8B), SEI_39 (6B), SEI_39 (23B), RAP_IDR_20 (18419B), RAP_IDR_20 (21407B), RAP_IDR_20 (22740B), RAP_IDR_20 (18401B)
```

5. Print single sample with an extra raw 112 bytes (some NALUs have a quite a big size, exceeding the raw bytes to be printed ) 
```
> mp4ff-nallister -c "hevc" -m 1 -raw 112  other_asset_with_video_track.cmfv
  Sample 1, pts=2000 (81137B):
   AUD_35 (3B) raw: 460110,
   VPS_32 (33B) raw: 40010c01ffff016000000300b0000003000003009615c0c000000300400000067a,
   SPS_33 (57B) raw: 420101016000000300b00000030000030096a001402005a16515e4914af014200000030280000003008000000cf86d7b9f8003d090007a1220,
   PPS_34 (8B) raw: 4401c0acbe25fb24,
   SEI_39 (6B) raw: 4e0181010380,
   SEI_39 (23B) raw: 4e01000a80000003004f1a0008ca100105040000620580,
   RAP_IDR_20 (18419B) raw: 2801af13b8e62194b2891d2a0a22479bc98e53753b3b32ea95e5a4bf71e769c73425426733ea19d6a37b05263bc49ffad264ab2aa8d23afe0f7569c5cdd72a142f33ca661bb65a90c03d7c97785b79de6802719d284c86c35f5c39e17795896fd82aa86bd4da28303ff3ca1271e5ea92...,
   RAP_IDR_20 (21407B) raw: 28012f03c4ee78d593cd094af18c14903ff11a53d287be2d41720bd7a46353c2c15c23f92615807796f80f4280ea8371e6fbecca1a39629a7a15af2527ea6dfd7cf35c85659974d1ee53174f6e02184d12844bd3e277bd1799ca0bdb2055e113cf90f16f80e7758d853575435a0ca33c...,
   RAP_IDR_20 (22740B) raw: 280120a3c4eee0c3952cd46d44159bed00d4619afee1fcb50c42b295f2ba4d3a1b6cae5be30cf2a39570d058c6ee1a3320301e8c648188f0ff7492b412581ae6ce568e36268dcb76a509e4639f70d0b53d50436e765e72c142bafdee7489563e19daf656114c2680a59ff1d634429de0...,
   RAP_IDR_20 (18401B) raw: 28012fa3c4ee835110e9be8459e7c9bb13ea82258af6532ef19209b88188c1d542f26274b7c57a4a95a653ad067fcea6a779f02265c870f07d80a97fd5bacc13df2f3839adb1b615b8a8b526f15a25d755d33a98f5d3cfcf2be43abfc57a3c2b67fdfac76c1d953e8c7a0889416d6f18...
>
```

6.  Print single sample with an extra raw 112 bytes and SEI (some NALUs have a quite a big size, exceeding the raw bytes to be printed ) 
```
> mp4ff-nallister -c "hevc" -m 1 -sei 1 -raw 112  other_asset_with_video_track.cmfv
  Sample 1, pts=2000 (81137B):
   AUD_35 (3B) raw: 460110,
   VPS_32 (33B) raw: 40010c01ffff016000000300b0000003000003009615c0c000000300400000067a,
   SPS_33 (57B) raw: 420101016000000300b00000030000030096a001402005a16515e4914af014200000030280000003008000000cf86d7b9f8003d090007a1220,
   PPS_34 (8B) raw: 4401c0acbe25fb24,
   SEI_39 (6B) raw: 4e0181010380,
   SEI_39 (23B) raw: 4e01000a80000003004f1a0008ca100105040000620580,
   RAP_IDR_20 (18419B) raw: 2801af13b8e62194b2891d2a0a22479bc98e53753b3b32ea95e5a4bf71e769c73425426733ea19d6a37b05263bc49ffad264ab2aa8d23afe0f7569c5cdd72a142f33ca661bb65a90c03d7c97785b79de6802719d284c86c35f5c39e17795896fd82aa86bd4da28303ff3ca1271e5ea92...,
   RAP_IDR_20 (21407B) raw: 28012f03c4ee78d593cd094af18c14903ff11a53d287be2d41720bd7a46353c2c15c23f92615807796f80f4280ea8371e6fbecca1a39629a7a15af2527ea6dfd7cf35c85659974d1ee53174f6e02184d12844bd3e277bd1799ca0bdb2055e113cf90f16f80e7758d853575435a0ca33c...,
   RAP_IDR_20 (22740B) raw: 280120a3c4eee0c3952cd46d44159bed00d4619afee1fcb50c42b295f2ba4d3a1b6cae5be30cf2a39570d058c6ee1a3320301e8c648188f0ff7492b412581ae6ce568e36268dcb76a509e4639f70d0b53d50436e765e72c142bafdee7489563e19daf656114c2680a59ff1d634429de0...,
   RAP_IDR_20 (18401B) raw: 28012fa3c4ee835110e9be8459e7c9bb13ea82258af6532ef19209b88188c1d542f26274b7c57a4a95a653ad067fcea6a779f02265c870f07d80a97fd5bacc13df2f3839adb1b615b8a8b526f15a25d755d33a98f5d3cfcf2be43abfc57a3c2b67fdfac76c1d953e8c7a0889416d6f18...
    SEI type 129, size=1, "03"
    SEI type 0, size=10, "800000004f1a0008ca10"
    SEI type 1, size=5, "0400006205"
```