### PR TITLE
Fix stricter tfdt time setting

### DIFF
--- a/aac/aac.go
+++ b/aac/aac.go
@@ -45,7 +45,7 @@ var FrequencyTable = map[byte]int{
 	12: 7350,
 }
 
-// ReversFrequencies converts sample frequency to index
+// ReverseFrequencies converts sample frequency to index
 var ReverseFrequencies = map[int]byte{
 	96000: 0,
 	88200: 1,

--- a/mp4/fragment.go
+++ b/mp4/fragment.go
@@ -112,7 +112,7 @@ func (f *Fragment) GetFullSamples(trex *TrexBox) ([]FullSample, error) {
 		traf = moof.Traf // The first one
 	}
 	tfhd := traf.Tfhd
-	baseTime := traf.Tfdt.BaseMediaDecodeTime
+	baseTime := traf.Tfdt.BaseMediaDecodeTime()
 	moofStartPos := moof.StartPos
 	var samples []FullSample
 	for _, trun := range traf.Truns {
@@ -359,7 +359,7 @@ func (f *Fragment) GetSampleNrFromTime(trex *TrexBox, sampleTime uint64) (uint32
 	if len(traf.Truns) != 1 {
 		return 0, fmt.Errorf("Not exactly one trun")
 	}
-	baseDecodeTime := traf.Tfdt.BaseMediaDecodeTime
+	baseDecodeTime := traf.Tfdt.BaseMediaDecodeTime()
 	if baseDecodeTime > sampleTime {
 		return 0, fmt.Errorf("sampleTime %d less that baseMediaDecodeTime %d", sampleTime, baseDecodeTime)
 	}
@@ -394,7 +394,7 @@ func (f *Fragment) GetSampleInterval(trex *TrexBox, startSampleNr, endSampleNr u
 		baseOffset = uint64(int64(trun.DataOffset) + int64(baseOffset))
 	}
 	offsetInMdat := uint32(baseOffset - f.Mdat.PayloadAbsoluteOffset())
-	return trun.GetSampleInterval(startSampleNr, endSampleNr, traf.Tfdt.BaseMediaDecodeTime, f.Mdat, offsetInMdat)
+	return trun.GetSampleInterval(startSampleNr, endSampleNr, traf.Tfdt.BaseMediaDecodeTime(), f.Mdat, offsetInMdat)
 }
 
 // AddSampleInterval - add SampleInterval for a fragment with only one track
@@ -403,7 +403,7 @@ func (f *Fragment) AddSampleInterval(sItvl SampleInterval) error {
 	traf := moof.Traf
 	trun := traf.Trun
 	if trun.sampleCount == 0 {
-		traf.Tfdt.BaseMediaDecodeTime = sItvl.FirstDecodeTime
+		traf.Tfdt.SetBaseMediaDecodeTime(sItvl.FirstDecodeTime)
 	}
 	trun.AddSamples(sItvl.Samples)
 	f.Mdat.AddSampleDataPart(sItvl.Data)

--- a/mp4/tfdt.go
+++ b/mp4/tfdt.go
@@ -12,7 +12,7 @@ import (
 type TfdtBox struct {
 	Version             byte
 	Flags               uint32
-	BaseMediaDecodeTime uint64
+	baseMediaDecodeTime uint64
 }
 
 // DecodeTfdt - box-specific decode
@@ -34,7 +34,7 @@ func DecodeTfdt(hdr BoxHeader, startPos uint64, r io.Reader) (Box, error) {
 	b := &TfdtBox{
 		Version:             version,
 		Flags:               versionAndFlags & flagsMask,
-		BaseMediaDecodeTime: baseMediaDecodeTime,
+		baseMediaDecodeTime: baseMediaDecodeTime,
 	}
 	return b, nil
 }
@@ -53,7 +53,7 @@ func DecodeTfdtSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, err
 	b := TfdtBox{
 		Version:             version,
 		Flags:               versionAndFlags & flagsMask,
-		BaseMediaDecodeTime: baseMediaDecodeTime,
+		baseMediaDecodeTime: baseMediaDecodeTime,
 	}
 	return &b, sr.AccError()
 }
@@ -67,18 +67,23 @@ func CreateTfdt(baseMediaDecodeTime uint64) *TfdtBox {
 	return &TfdtBox{
 		Version:             version,
 		Flags:               0,
-		BaseMediaDecodeTime: baseMediaDecodeTime,
+		baseMediaDecodeTime: baseMediaDecodeTime,
 	}
 }
 
-// SetBaseMediaDecodeTime - Set time of TfdtBox
+// BaseMediaDecodeTime is the base media decode time.
+func (t *TfdtBox) BaseMediaDecodeTime() uint64 {
+	return t.baseMediaDecodeTime
+}
+
+// SetBaseMediaDecodeTime sets base media decode time of TfdtBox.
 func (t *TfdtBox) SetBaseMediaDecodeTime(bTime uint64) {
 	if bTime >= 4294967296 {
 		t.Version = 1
 	} else {
 		t.Version = 0
 	}
-	t.BaseMediaDecodeTime = bTime
+	t.baseMediaDecodeTime = bTime
 }
 
 // Type - return box type
@@ -111,9 +116,9 @@ func (t *TfdtBox) EncodeSW(sw bits.SliceWriter) error {
 	versionAndFlags := (uint32(t.Version) << 24) + t.Flags
 	sw.WriteUint32(versionAndFlags)
 	if t.Version == 0 {
-		sw.WriteUint32(uint32(t.BaseMediaDecodeTime))
+		sw.WriteUint32(uint32(t.BaseMediaDecodeTime()))
 	} else {
-		sw.WriteUint64(t.BaseMediaDecodeTime)
+		sw.WriteUint64(t.BaseMediaDecodeTime())
 	}
 	return sw.AccError()
 }
@@ -121,6 +126,6 @@ func (t *TfdtBox) EncodeSW(sw bits.SliceWriter) error {
 // Info - write box info to w
 func (t *TfdtBox) Info(w io.Writer, specificBoxLevels, indent, indentStep string) (err error) {
 	bd := newInfoDumper(w, indent, t, int(t.Version), t.Flags)
-	bd.write(" - baseMediaDecodeTime: %d", t.BaseMediaDecodeTime)
+	bd.write(" - baseMediaDecodeTime: %d", t.BaseMediaDecodeTime())
 	return bd.err
 }

--- a/mp4/tfdt_test.go
+++ b/mp4/tfdt_test.go
@@ -21,8 +21,8 @@ func TestTfdtReadingV0(t *testing.T) {
 	if tfdt.Version != 0 {
 		t.Errorf("Tfdt version is not 0")
 	}
-	if tfdt.BaseMediaDecodeTime != 0x00ffffff {
-		t.Errorf("Tfdt basemediaDecodeTime is %v not %v", tfdt.BaseMediaDecodeTime, 0x00ffffff)
+	if tfdt.BaseMediaDecodeTime() != 0x00ffffff {
+		t.Errorf("Tfdt basemediaDecodeTime is %x not %x", tfdt.BaseMediaDecodeTime(), 0x00ffffff)
 	}
 }
 
@@ -41,8 +41,8 @@ func TestTfdtReadingV1(t *testing.T) {
 	if tfdt.Version != 1 {
 		t.Errorf("Tfdt version is not 1")
 	}
-	if tfdt.BaseMediaDecodeTime != 0x00ffffff {
-		t.Errorf("Tfdt basemediaDecodeTime is %v not %v", tfdt.BaseMediaDecodeTime, 0x00ffffff)
+	if tfdt.BaseMediaDecodeTime() != 0x00ffffff {
+		t.Errorf("Tfdt basemediaDecodeTime is %x not %x", tfdt.BaseMediaDecodeTime(), 0x00ffffff)
 	}
 }
 


### PR DESCRIPTION
Changed BaseMediaDecodeTime of TfdtBox to have a setter that sets the version flag properly.
There was a bug in `AddSampleInterval` where the flag was not properly set.