### PR TITLE
NALU extraction from byte streams

### DIFF
--- a/avc/annexb_test.go
+++ b/avc/annexb_test.go
@@ -143,3 +143,54 @@ func TestGetParameterSetsFromByteStream(t *testing.T) {
 		}
 	}
 }
+
+func TestExtractNalusOfTypeFromByteStream(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       []byte
+		naluType    NaluType
+		beyondVideo bool
+		nrWanted    int
+	}{
+		{
+			"Only IDR. Search PPS",
+			[]byte{0, 0, 0, 1, 5, 0, 1, 1, 1, 1},
+			NALU_PPS,
+			true,
+			0,
+		},
+		{
+			"Only IDR, excl video",
+			[]byte{0, 0, 0, 1, 5, 0, 1, 1, 1, 1, 1},
+			NALU_IDR,
+			true,
+			0,
+		},
+		{
+			"Only IDR, incl video",
+			[]byte{0, 0, 0, 1, 5, 0, 1, 1, 1, 1, 1},
+			NALU_IDR,
+			false,
+			1,
+		},
+		{
+			"AUD, SPS, PPS, IDRx2",
+			[]byte{0, 0, 0, 1, 9, 2,
+				0, 0, 0, 1, 7, 5, 4,
+				0, 0, 0, 1, 8, 1, 2,
+				0, 0, 0, 1, 5, 0,
+				0, 0, 0, 1, 5, 0,
+				1, 1, 1, 1, 1, 1},
+			NALU_PPS,
+			false,
+			1,
+		},
+	}
+
+	for _, tc := range testCases {
+		nrNalus := ExtractNalusOfTypeFromByteStream(tc.naluType, tc.input, tc.beyondVideo)
+		if len(nrNalus) != tc.nrWanted {
+			t.Errorf("%q: got %d, wanted %d", tc.name, len(nrNalus), tc.nrWanted)
+		}
+	}
+}

--- a/hevc/annexb_test.go
+++ b/hevc/annexb_test.go
@@ -45,3 +45,54 @@ func TestGetParameterSetsFromByteStream(t *testing.T) {
 		}
 	}
 }
+
+func TestExtractNalusOfTypeFromByteStream(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       []byte
+		naluType    NaluType
+		beyondVideo bool
+		nrWanted    int
+	}{
+		{
+			"Only IDR. Search PPS",
+			[]byte{0, 0, 0, 1, byte(NALU_IDR_W_RADL) << 1, 0, 1, 1, 1, 1},
+			NALU_PPS,
+			true,
+			0,
+		},
+		{
+			"Only IDR, excl video",
+			[]byte{0, 0, 0, 1, byte(NALU_IDR_W_RADL) << 1, 0, 1, 1, 1, 1, 1},
+			NALU_IDR_W_RADL,
+			true,
+			0,
+		},
+		{
+			"Only IDR, incl video",
+			[]byte{0, 0, 0, 1, byte(NALU_IDR_W_RADL) << 1, 0, 1, 1, 1, 1, 1},
+			NALU_IDR_W_RADL,
+			false,
+			1,
+		},
+		{
+			"AUD, SPS, PPS, IDR",
+			[]byte{0, 0, 0, 1, byte(NALU_AUD) << 1, 2, 0,
+				0, 0, 0, 1, byte(NALU_VPS) << 1, 5, 4,
+				0, 0, 0, 1, byte(NALU_SPS) << 1, 1, 2,
+				0, 0, 0, 1, byte(NALU_PPS) << 1, 5, 0,
+				0, 0, 0, 1, byte(NALU_IDR_W_RADL) << 1, 0,
+				1, 1, 1, 1, 1, 1},
+			NALU_PPS,
+			false,
+			1,
+		},
+	}
+
+	for _, tc := range testCases {
+		nrNalus := ExtractNalusOfTypeFromByteStream(tc.naluType, tc.input, tc.beyondVideo)
+		if len(nrNalus) != tc.nrWanted {
+			t.Errorf("%q: got %d, wanted %d", tc.name, len(nrNalus), tc.nrWanted)
+		}
+	}
+}


### PR DESCRIPTION
New methods for both AVC and HEVC to extract NALUs of specific types from bytestreams.