### PR TITLE
Using box header's size as prft's size

### DIFF
--- a/mp4/boxsr.go
+++ b/mp4/boxsr.go
@@ -227,6 +227,9 @@ LoopBoxes:
 		f.AddChild(box, boxStartPos)
 		lastBoxType = boxType
 		boxStartPos += boxSize
+		if sr.GetPos() != int(boxStartPos) {
+			sr.SetPos(int(boxStartPos))
+		}
 	}
 	return f, nil
 }

--- a/mp4/prft.go
+++ b/mp4/prft.go
@@ -14,6 +14,7 @@ type PrftBox struct {
 	Flags        uint32
 	NTPTimestamp uint64
 	MediaTime    uint64
+	size 		 uint64
 }
 
 // CreatePrftBox - Create a new PrftBox
@@ -54,6 +55,7 @@ func DecodePrftSR(hdr BoxHeader, startPos uint64, sr bits.SliceReader) (Box, err
 		Flags:        flags,
 		NTPTimestamp: ntp,
 		MediaTime:    mediatime,
+		size:         hdr.Size,
 	}
 	return &p, sr.AccError()
 }
@@ -65,6 +67,9 @@ func (b *PrftBox) Type() string {
 
 // Size - return calculated size
 func (b *PrftBox) Size() uint64 {
+	if b.size > 0{
+		return b.size
+	}
 	return uint64(boxHeaderSize + 16 + 4*int(b.Version))
 }
 

--- a/mp4/prft.go
+++ b/mp4/prft.go
@@ -14,7 +14,7 @@ type PrftBox struct {
 	Flags        uint32
 	NTPTimestamp uint64
 	MediaTime    uint64
-	size 		 uint64
+	size         uint64
 }
 
 // CreatePrftBox - Create a new PrftBox


### PR DESCRIPTION
While I was using this code to decode a CMAF stream, and found that sometimes the size of `prft` is larger than 24 (8+4+8+4) bytes even if the version equals 0, and ends with several 0x00 or other bytes.  This might cause error `Size 0, meaning to end of file, not supported` or `Read too far in SliceReader` when reading the next box using `DecodeFileSR`.
So I use box header's size as prft's size, and if other boxes haven't read completely (sr's pos might cause some problem), to set sr's pos by boxStartPos in `DecodeFileSR`

This is an example of prft what I described
![1669893088009](https://user-images.githubusercontent.com/18064862/205038327-f435b8d1-7730-473e-b22d-9d38d9e030dc.jpg)

