### PR TITLE
version 0.31.0

### DIFF
--- a/Versions.md
+++ b/Versions.md
@@ -2,6 +2,7 @@
 
 | Version | Highlight |
 | ------  | --------- |
+| 0.31.0 | Support multiple sidx. Optimize stsc lookups. New return type for NewNaluArray. Bug fixes in prft, adts and avc interlace.
 | 0.30.1 | Fix optimized sample copying introduced in v0.30.0 |
 | 0.30.0 | Full AVC slice header parsing. Enhanced SEI Messages. Optimizations in ctts and sample copying. Bug fixes in HEVC nalu, tfdt, emsg |
 | 0.29.0 | Improved uuid and esds box handling. Extended decryption example with cbcs and in-place cenc decryption |

--- a/mp4/version.go
+++ b/mp4/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	commitVersion string = "v0.30.1"    // May be updated using build flags
-	commitDate    string = "1667671435" // commitDate in Epoch seconds (may be overridden using build flags)
+	commitVersion string = "v0.31.0"    // May be updated using build flags
+	commitDate    string = "1672185600" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 
 // GetVersion - get version and also commitHash and commitDate if inserted via Makefile


### PR DESCRIPTION
- Support multiple sidx
- Optimize stsc lookups.
- New return type for NewNaluArray. 
- Bug fixes in prft, adts and avc interlace.
- Covered by PRs 190-197, and 199